### PR TITLE
Volume.getMigrateStatus should return null by default

### DIFF
--- a/core/src/main/java/org/openstack4j/openstack/storage/block/domain/CinderVolume.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/block/domain/CinderVolume.java
@@ -179,7 +179,7 @@ public class CinderVolume implements Volume {
 	 */
 	@Override
 	public MigrationStatus getMigrateStatus() {
-		return migrateStatus != null ? migrateStatus : MigrationStatus.NONE;
+		return migrateStatus;
 	}
 
 	/**


### PR DESCRIPTION
Fix #9 
...and hopefully fix [Jenkins OpenStack-cloud-plugin bug 277](https://github.com/jenkinsci/openstack-cloud-plugin/issues/277) in the process.

Summary of changes:

1. The CinderVolume POJO now "just does what it's told" and doesn't second-guess what the MigrationStatus should be.
This should then fix the issue where the outgoing JSON request updated the migration status when no such change was requested.

1. Any (external) caller _reading_ this field should be sufficiently null-proofed by Volume.MigrationStatus.fromValue's null-handling functionality where, when turning JSON to Java, a null JSON string is turned into MigrationStatus.NONE.

i.e. the POJO will (now) retain null as null when writing but anyone reading the data back again will read MigrationStatus.NONE.