### PR TITLE
Fix #6: Declare api deprecated to rise user awereness services will be removed

### DIFF
--- a/core/src/main/java/org/openstack4j/api/compute/ComputeFloatingIPService.java
+++ b/core/src/main/java/org/openstack4j/api/compute/ComputeFloatingIPService.java
@@ -11,7 +11,10 @@ import org.openstack4j.model.compute.Server;
  * OpenStack Compute Floating-IP Operation API.
  *
  * @author Nathan Anderson
+ * @deprecated This API is a proxy call to the Network service. Nova has deprecated all the proxy APIs and users should use the native APIs instead. This API will fail with a 404 starting from microversion 2.36.
+ * @see org.openstack4j.api.networking.NetFloatingIPService
  */
+@Deprecated
 public interface ComputeFloatingIPService extends RestService {
 
 	/**

--- a/core/src/main/java/org/openstack4j/api/compute/ComputeImageService.java
+++ b/core/src/main/java/org/openstack4j/api/compute/ComputeImageService.java
@@ -11,7 +11,10 @@ import org.openstack4j.model.compute.Image;
  * Provides access to Compute Images
  * 
  * @author Jeremy Unruh
+ * @deprecated These APIs are proxy calls to the Image service. Nova has deprecated all the proxy APIs and users should use the native APIs instead. All the Image services proxy APIs except image metadata APIs will fail with a 404 starting from microversion 2.36. The image metadata APIs will fail with a 404 starting from microversion 2.39.
+ * @see org.openstack4j.api.image.v2.ImageService
  */
+@Deprecated
 public interface ComputeImageService extends RestService {
 
 	/**

--- a/core/src/main/java/org/openstack4j/api/compute/ComputeSecurityGroupService.java
+++ b/core/src/main/java/org/openstack4j/api/compute/ComputeSecurityGroupService.java
@@ -13,7 +13,10 @@ import org.openstack4j.model.compute.SecGroupExtension.Rule;
  * Extension Mapping: (os-security-groups)
  * 
  * @author Jeremy Unruh
+ * @deprecated These APIs are proxy calls to the Network service. Nova has deprecated all the proxy APIs and users should use the native APIs instead. These will fail with a 404 starting from microversion 2.36
+ * @see org.openstack4j.api.networking.SecurityGroupService
  */
+@Deprecated
 public interface ComputeSecurityGroupService extends RestService {
 
 	/**

--- a/core/src/main/java/org/openstack4j/api/compute/ComputeService.java
+++ b/core/src/main/java/org/openstack4j/api/compute/ComputeService.java
@@ -96,7 +96,9 @@ public interface ComputeService extends RestService {
 	
 	/**
 	 * @return a list of Extensions that have been added against the Compute service
+	 * @deprecated https://specs.openstack.org/openstack/nova-specs/specs/newton/implemented/api-no-more-extensions.html
 	 */
+	@Deprecated
 	List<? extends Extension> listExtensions();
 	
 	/**

--- a/core/src/main/java/org/openstack4j/api/compute/ComputeService.java
+++ b/core/src/main/java/org/openstack4j/api/compute/ComputeService.java
@@ -28,7 +28,10 @@ public interface ComputeService extends RestService {
 	 * Image Service API
 	 *
 	 * @return the image service
+	 * @deprecated These APIs are proxy calls to the Image service. Nova has deprecated all the proxy APIs and users should use the native APIs instead. All the Image services proxy APIs except image metadata APIs will fail with a 404 starting from microversion 2.36. The image metadata APIs will fail with a 404 starting from microversion 2.39.
+	 * @see org.openstack4j.api.image.v2.ImageService
 	 */
+	@Deprecated
 	ComputeImageService images();
 	
 	/**
@@ -63,21 +66,30 @@ public interface ComputeService extends RestService {
 	 * Compute Os-Host API
 	 *
 	 * @return the compute os-host service
+	 * @deprecated The os-hosts API is deprecated as of the 2.43 microversion. Requests made with microversion >= 2.43 will result in a 404 error. To list and show host details, use the Hypervisors (os-hypervisors) API. To enable or disable a service, use the Compute services (os-services) API. There is no replacement for the shutdown, startup, reboot, or maintenance_mode actions as those are system-level operations which should be outside of the control of the compute service.
+	 * @see ServerService
 	 */
+	@Deprecated
 	HostService host();
 
 	/**
 	 * Floating IP Service API
 	 *
 	 * @return the floating-ip service
+	 * @deprecated This API is a proxy call to the Network service. Nova has deprecated all the proxy APIs and users should use the native APIs instead. This API will fail with a 404 starting from microversion 2.36.
+	 * @see org.openstack4j.api.networking.NetFloatingIPService
 	 */
+	@Deprecated
 	ComputeFloatingIPService floatingIps();
 	
 	/**
 	 * Security Groups Extension API
 	 * 
 	 * @return the security groups service
+	 * @deprecated These APIs are proxy calls to the Network service. Nova has deprecated all the proxy APIs and users should use the native APIs instead. These will fail with a 404 starting from microversion 2.36
+	 * @see org.openstack4j.api.networking.SecurityGroupService
 	 */
+	@Deprecated
 	ComputeSecurityGroupService securityGroups();
 	
 	/**
@@ -112,8 +124,11 @@ public interface ComputeService extends RestService {
 	 * Service that manages the extension 'os-floating-ip-dns'
 	 * 
 	 * @return the floating IP DNS Service
+	 * @deprecated Since these APIs are only implemented for nova-network, they are deprecated. These will fail with a 404 starting from microversion 2.36. They were removed in the 18.0.0 Rocky release.
 	 */
+	@Deprecated
 	FloatingIPDNSService floatingIPDNS();
+
 	/**
 	 * Host Aggregates Management Service
 	 */

--- a/core/src/main/java/org/openstack4j/api/compute/HostService.java
+++ b/core/src/main/java/org/openstack4j/api/compute/HostService.java
@@ -10,8 +10,10 @@ import org.openstack4j.model.compute.HostResource;
  * Nova OS Host Service
  * 
  * @author Qin An
- *
+ * @deprecated The os-hosts API is deprecated as of the 2.43 microversion. Requests made with microversion >= 2.43 will result in a 404 error. To list and show host details, use the Hypervisors (os-hypervisors) API. To enable or disable a service, use the Compute services (os-services) API. There is no replacement for the shutdown, startup, reboot, or maintenance_mode actions as those are system-level operations which should be outside of the control of the compute service.
+ * @see ServerService
  */
+@Deprecated
 public interface HostService extends RestService {
 
     /**

--- a/core/src/main/java/org/openstack4j/api/compute/ext/FloatingIPDNSDomainService.java
+++ b/core/src/main/java/org/openstack4j/api/compute/ext/FloatingIPDNSDomainService.java
@@ -11,6 +11,7 @@ import org.openstack4j.model.compute.ext.DomainEntry;
  * 
  * @author Jeremy Unruh
  */
+@Deprecated
 public interface FloatingIPDNSDomainService extends RestService {
 
     /**

--- a/core/src/main/java/org/openstack4j/api/compute/ext/FloatingIPDNSEntryService.java
+++ b/core/src/main/java/org/openstack4j/api/compute/ext/FloatingIPDNSEntryService.java
@@ -12,6 +12,7 @@ import org.openstack4j.model.compute.ext.DNSRecordType;
  * 
  * @author Jeremy Unruh
  */
+@Deprecated
 public interface FloatingIPDNSEntryService extends RestService {
 
     /**

--- a/core/src/main/java/org/openstack4j/api/compute/ext/FloatingIPDNSService.java
+++ b/core/src/main/java/org/openstack4j/api/compute/ext/FloatingIPDNSService.java
@@ -4,7 +4,9 @@ package org.openstack4j.api.compute.ext;
  * API Service that manages the 'os-floating-ip-dns' extension
  * 
  * @author Jeremy Unruh
+ * @deprecated Since these APIs are only implemented for nova-network, they are deprecated. These will fail with a 404 starting from microversion 2.36. They were removed in the 18.0.0 Rocky release.
  */
+@Deprecated
 public interface FloatingIPDNSService {
 
     /**

--- a/core/src/main/java/org/openstack4j/api/identity/v2/IdentityService.java
+++ b/core/src/main/java/org/openstack4j/api/identity/v2/IdentityService.java
@@ -45,7 +45,9 @@ public interface IdentityService extends RestService {
 	 * List extensions currently available on the OpenStack instance
 	 *
 	 * @return List of extensions
+	 * @deprecated https://docs.openstack.org/api-ref/compute/?expanded=#extensions-extensions-deprecated
 	 */
+	@Deprecated
 	List<? extends Extension> listExtensions();
 	
 	/**

--- a/core/src/main/java/org/openstack4j/api/identity/v3/IdentityService.java
+++ b/core/src/main/java/org/openstack4j/api/identity/v3/IdentityService.java
@@ -85,7 +85,9 @@ public interface IdentityService extends RestService {
      * List extensions currently available on the OpenStack instance
      *
      * @return List of extensions
+     * @deprecated https://docs.openstack.org/api-ref/compute/?expanded=#extensions-extensions-deprecated
      */
+    @Deprecated
     List<? extends Extension> listExtensions();
 
 }

--- a/core/src/main/java/org/openstack4j/api/manila/ShareService.java
+++ b/core/src/main/java/org/openstack4j/api/manila/ShareService.java
@@ -16,7 +16,9 @@ import java.util.List;
 public interface ShareService extends RestService {
     /**
      * @return a list of available Shared File Systems API extensions
+     * @deprecated https://docs.openstack.org/api-ref/compute/?expanded=#extensions-extensions-deprecated
      */
+    @Deprecated
     List<? extends Extension> listExtensions();
 
     /**

--- a/core/src/main/java/org/openstack4j/model/common/Extension.java
+++ b/core/src/main/java/org/openstack4j/model/common/Extension.java
@@ -10,7 +10,9 @@ import org.openstack4j.model.ModelEntity;
  * Represents an Extension which adds additional functionality to the OpenStack API
  * 
  * @author Jeremy Unruh
+ * @deprecated https://specs.openstack.org/openstack/nova-specs/specs/newton/implemented/api-no-more-extensions.html
  */
+@Deprecated
 public interface Extension extends ModelEntity {
 
 	/**

--- a/core/src/main/java/org/openstack4j/openstack/common/ExtensionValue.java
+++ b/core/src/main/java/org/openstack4j/openstack/common/ExtensionValue.java
@@ -15,7 +15,9 @@ import java.util.List;
  * Represents an Extension which adds additional functionality to the OpenStack API
  *
  * @author Jeremy Unruh
+ * @deprecated https://specs.openstack.org/openstack/nova-specs/specs/newton/implemented/api-no-more-extensions.html
  */
+@Deprecated
 public class ExtensionValue implements Extension {
 
 	private static final long serialVersionUID = 1L;

--- a/core/src/main/java/org/openstack4j/openstack/compute/internal/ComputeFloatingIPServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/internal/ComputeFloatingIPServiceImpl.java
@@ -22,6 +22,7 @@ import org.openstack4j.openstack.compute.functions.ToActionResponseFunction;
  *
  * @author Nathan Anderson
  */
+@Deprecated
 public class ComputeFloatingIPServiceImpl extends BaseComputeServices implements ComputeFloatingIPService {
 
     /**

--- a/core/src/main/java/org/openstack4j/openstack/compute/internal/ComputeImageServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/internal/ComputeImageServiceImpl.java
@@ -17,6 +17,7 @@ import org.openstack4j.openstack.compute.domain.NovaImage.NovaImages;
  *
  * @author Jeremy Unruh
  */
+@Deprecated
 public class ComputeImageServiceImpl extends BaseComputeServices implements ComputeImageService {
 
 	/**

--- a/core/src/main/java/org/openstack4j/openstack/compute/internal/ComputeSecurityGroupServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/internal/ComputeSecurityGroupServiceImpl.java
@@ -19,6 +19,7 @@ import org.openstack4j.openstack.compute.domain.NovaSecGroupExtension.SecurityGr
  * 
  * @author Jeremy Unruh
  */
+@Deprecated
 public class ComputeSecurityGroupServiceImpl extends BaseComputeServices implements ComputeSecurityGroupService {
 
 	/**

--- a/core/src/main/java/org/openstack4j/openstack/compute/internal/HostServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/internal/HostServiceImpl.java
@@ -16,6 +16,7 @@ import org.openstack4j.openstack.compute.domain.NovaHostResource.NovaHostResourc
  * @author Qin An
  *
  */
+@Deprecated
 public class HostServiceImpl extends BaseComputeServices implements HostService {
 
     @Override

--- a/core/src/main/java/org/openstack4j/openstack/compute/internal/ext/FloatingIPDNSDomainServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/internal/ext/FloatingIPDNSDomainServiceImpl.java
@@ -17,6 +17,7 @@ import org.openstack4j.openstack.compute.internal.BaseComputeServices;
  * 
  * @author Jeremy Unruh
  */
+@Deprecated
 public class FloatingIPDNSDomainServiceImpl extends BaseComputeServices implements FloatingIPDNSDomainService {
 
     @Override

--- a/core/src/main/java/org/openstack4j/openstack/compute/internal/ext/FloatingIPDNSEntryServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/internal/ext/FloatingIPDNSEntryServiceImpl.java
@@ -17,6 +17,7 @@ import org.openstack4j.openstack.compute.internal.BaseComputeServices;
  * 
  * @author Jeremy Unruh
  */
+@Deprecated
 public class FloatingIPDNSEntryServiceImpl extends BaseComputeServices implements FloatingIPDNSEntryService {
 
     @Override

--- a/core/src/main/java/org/openstack4j/openstack/compute/internal/ext/FloatingIPDNSServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/internal/ext/FloatingIPDNSServiceImpl.java
@@ -10,6 +10,7 @@ import org.openstack4j.api.compute.ext.FloatingIPDNSService;
  * 
  * @author Jeremy Unruh
  */
+@Deprecated
 public class FloatingIPDNSServiceImpl implements FloatingIPDNSService {
 
     @Override


### PR DESCRIPTION
Some API we support interact with deprecated API endpoints. Since we are providing a nice wrapper around the REST API, users can be unaware the features they depend on are going to be removed.

This essentially propagates the information of what is deprecated from OS reference documentation to the code, so it is easier to users to notice.

https://docs.openstack.org/api-ref/compute/