### PR TITLE
Propagate failures from net FloatingIPService#create

### DIFF
--- a/connectors/http-connector/src/main/java/org/openstack4j/connectors/http/HttpCommand.java
+++ b/connectors/http-connector/src/main/java/org/openstack4j/connectors/http/HttpCommand.java
@@ -96,12 +96,9 @@ public final class HttpCommand<R> {
                 out.write(requestBody);
                 out.flush();
             }
-            byte[] data = null;
 
             int status = connection.getResponseCode();
-            if (status >= 200 && status < 300) {
-                data = ByteStreams.toByteArray(connection.getInputStream());
-            }
+            byte[] data = getResponseBytes();
             return HttpResponseImpl.wrap(connection.getHeaderFields(),
                     status, connection.getResponseMessage(),
                     data);
@@ -112,6 +109,21 @@ public final class HttpCommand<R> {
         } finally {
             connection.disconnect();
         }
+    }
+
+    // https://stackoverflow.com/a/613484/2091470
+    private byte[] getResponseBytes() throws IOException {
+        InputStream is;
+        try {
+            is = connection.getInputStream();
+        } catch (IOException ex) {
+            is = connection.getErrorStream();
+        }
+
+        if (is != null) {
+            return ByteStreams.toByteArray(is);
+        }
+        return null;
     }
 
     /**

--- a/core-test/src/main/java/org/openstack4j/api/network/NetFloatingIPServiceTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/network/NetFloatingIPServiceTests.java
@@ -1,0 +1,53 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) Red Hat, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.openstack4j.api.network;
+
+import org.openstack4j.api.AbstractTest;
+import org.openstack4j.api.Builders;
+import org.openstack4j.api.exceptions.ClientResponseException;
+import org.openstack4j.model.network.NetFloatingIP;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+@Test(suiteName = "Network Floating IPs Tests")
+public class NetFloatingIPServiceTests extends AbstractTest {
+
+    @Override
+    protected Service service() {
+        return Service.NETWORK;
+    }
+
+    public void testCreateFailure() throws Exception {
+        respondWithCodeAndResource(404, "/network/network_fips_create_fail.json");
+
+        NetFloatingIP fip = Builders.netFloatingIP().floatingNetworkId("42").build();
+        try {
+            osv3().networking().floatingip().create(fip);
+            fail("Expected to fail");
+        } catch (ClientResponseException expected) {
+            assertTrue(expected.toString().contains("is not reachable from subnet"), expected.toString());
+        }
+    }
+}

--- a/core-test/src/main/resources/network/network_fips_create_fail.json
+++ b/core-test/src/main/resources/network/network_fips_create_fail.json
@@ -1,0 +1,7 @@
+{
+  "NeutronError": {
+    "message": "External network 25ec4907-36fc-4035-b8d5-b797246330f2 is not reachable from subnet eb8db9f4-a76f-4fe2-a0bd-f932bc20dfa1.  Therefore, cannot associate Port 1c852648-f504-4fb1-9d97-83731642d4cf with a Floating IP.",
+    "type": "ExternalGatewayForFloatingIPNotFound",
+    "detail": ""
+  }
+}

--- a/core/src/main/java/org/openstack4j/core/transport/HttpEntityHandler.java
+++ b/core/src/main/java/org/openstack4j/core/transport/HttpEntityHandler.java
@@ -36,6 +36,7 @@ public class HttpEntityHandler {
                     return (T) ResponseToActionResponse.INSTANCE.apply(response);
                 }
 
+
                 if (options != null) {
                     options.propagate(response);
                 }

--- a/core/src/main/java/org/openstack4j/core/transport/HttpEntityHandler.java
+++ b/core/src/main/java/org/openstack4j/core/transport/HttpEntityHandler.java
@@ -36,7 +36,6 @@ public class HttpEntityHandler {
                     return (T) ResponseToActionResponse.INSTANCE.apply(response);
                 }
 
-
                 if (options != null) {
                     options.propagate(response);
                 }

--- a/core/src/main/java/org/openstack4j/core/transport/functions/ResponseToActionResponse.java
+++ b/core/src/main/java/org/openstack4j/core/transport/functions/ResponseToActionResponse.java
@@ -33,7 +33,7 @@ public class ResponseToActionResponse implements Function<HttpResponse, ActionRe
         if (ar != null)
             return ar;
 
-        if (ar == null && returnNullIfNotMapped)
+        if (returnNullIfNotMapped)
             return null;
 
         return ActionResponse.actionFailed(String.format("Status: %d, Reason: %s", response.getStatus(), response.getStatusMessage()), response.getStatus());

--- a/core/src/main/java/org/openstack4j/openstack/networking/internal/FloatingIPServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/internal/FloatingIPServiceImpl.java
@@ -67,7 +67,8 @@ public class FloatingIPServiceImpl extends BaseNetworkingServices implements Net
     public NetFloatingIP create(NetFloatingIP floatingIp) {
         checkNotNull(floatingIp);
         checkNotNull(floatingIp.getFloatingNetworkId());
-        return post(NeutronFloatingIP.class, uri("/floatingips")).entity(floatingIp).execute(); 
+        return post(NeutronFloatingIP.class, uri("/floatingips")).entity(floatingIp)
+                .execute(ExecutionOptions.create(PropagateOnStatus.on(404)));
     }
 
     /**
@@ -80,7 +81,7 @@ public class FloatingIPServiceImpl extends BaseNetworkingServices implements Net
         String inner = String.format("{ \"port_id\":\"%s\" }", portId);
         String json = String.format("{ \"%s\": %s }", "floatingip", inner);
         return put(NeutronFloatingIP.class, uri("/floatingips/%s",id)).json(json)
-                .execute(ExecutionOptions.<NeutronFloatingIP>create(PropagateOnStatus.on(404)));
+                .execute(ExecutionOptions.create(PropagateOnStatus.on(404)));
 
     }
 
@@ -92,6 +93,6 @@ public class FloatingIPServiceImpl extends BaseNetworkingServices implements Net
         checkNotNull(id);
         String json = String.format("{ \"%s\": %s }", "floatingip", "{ \"port_id\":null }");
         return put(NeutronFloatingIP.class, uri("/floatingips/%s",id)).json(json)
-                .execute(ExecutionOptions.<NeutronFloatingIP>create(PropagateOnStatus.on(404)));
+                .execute(ExecutionOptions.create(PropagateOnStatus.on(404)));
     }
 }


### PR DESCRIPTION
Make sure the failure to assign floating IP is not silently ignored.

This also fixes #28, as without that it was not possible to verify the fix (on given connector only).