### PR TITLE
Neutron 2: Update NetFloatingIP to fetch and set all the fields

### DIFF
--- a/core-test/src/main/java/org/openstack4j/api/network/NetFloatingIPServiceTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/network/NetFloatingIPServiceTests.java
@@ -29,6 +29,10 @@ import org.openstack4j.api.exceptions.ClientResponseException;
 import org.openstack4j.model.network.NetFloatingIP;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
 import static org.testng.Assert.*;
 
 @Test(suiteName = "Network Floating IPs Tests")
@@ -49,5 +53,46 @@ public class NetFloatingIPServiceTests extends AbstractTest {
         } catch (ClientResponseException expected) {
             assertTrue(expected.toString().contains("is not reachable from subnet"), expected.toString());
         }
+    }
+
+    @Test
+    public void listIps() throws Exception {
+        respondWith("/network/network_fips_list.json");
+
+        List<? extends NetFloatingIP> list = osv3().networking().floatingip().list();
+        assertEquals(list.size(), 2);
+        NetFloatingIP used = list.get(0);
+        assertEquals(used.getStatus(), "ACTIVE");
+        assertEquals(used.getRouterId(), "4910645f-7efe-4c37-918e-3ace85162985");
+        assertEquals("", used.getDescription());
+        assertEquals(used.getTags(), Collections.emptyList());
+        assertEquals(used.getProjectId(), "e68d5f9cb37844ecbd793632944f4459");
+        assertEquals(used.getTenantId(), "e68d5f9cb37844ecbd793632944f4459");
+        assertEquals(used.getCreatedAt(), new Date(1584733565000L));
+        assertEquals(used.getUpdatedAt(), new Date(1584733569000L));
+        assertEquals(used.getFloatingNetworkId(), "38cc9e61-11fc-4921-843d-80ef249a3710");
+        assertEquals(used.getFixedIpAddress(), "10.0.51.16");
+        assertEquals(used.getFloatingIpAddress(), "10.0.50.29");
+        assertEquals(used.getPortId(), "7095d432-a007-4d6b-9549-683cd1566188");
+        assertEquals(used.getId(), "530e2826-ae43-4cde-bd7c-856a33a3061d");
+        assertNull(used.getQosPolicyId());
+        assertEquals(1, used.getRevisionNumber().intValue());
+
+        NetFloatingIP idle = list.get(1);
+        assertEquals(idle.getStatus(), "DOWN");
+        assertNull(idle.getRouterId());
+        assertEquals("idle", idle.getDescription());
+        assertEquals(idle.getTags(), Collections.emptyList());
+        assertEquals(idle.getProjectId(), "d7e88181cd044db188592070ec8bf8b4");
+        assertEquals(idle.getTenantId(), "d7e88181cd044db188592070ec8bf8b4");
+        assertEquals(idle.getCreatedAt(), new Date(1584706487000L));
+        assertEquals(idle.getUpdatedAt(), new Date(1584706487000L));
+        assertEquals(idle.getFloatingNetworkId(), "38cc9e61-11fc-4921-843d-80ef249a3710");
+        assertNull(idle.getFixedIpAddress());
+        assertEquals(idle.getFloatingIpAddress(), "10.0.50.8");
+        assertNull(idle.getPortId());
+        assertEquals(idle.getId(), "65297c50-2c6e-4c5f-96eb-8b4c228cd54c");
+        assertNull(idle.getQosPolicyId());
+        assertEquals(0, idle.getRevisionNumber().intValue());
     }
 }

--- a/core-test/src/main/resources/network/network_fips_list.json
+++ b/core-test/src/main/resources/network/network_fips_list.json
@@ -1,0 +1,38 @@
+{
+  "floatingips": [
+    {
+      "router_id": "4910645f-7efe-4c37-918e-3ace85162985",
+      "status": "ACTIVE",
+      "description": "",
+      "tags": [],
+      "tenant_id": "e68d5f9cb37844ecbd793632944f4459",
+      "created_at": "2020-03-20T19:46:05Z",
+      "updated_at": "2020-03-20T19:46:09Z",
+      "floating_network_id": "38cc9e61-11fc-4921-843d-80ef249a3710",
+      "fixed_ip_address": "10.0.51.16",
+      "floating_ip_address": "10.0.50.29",
+      "revision_number": 1,
+      "project_id": "e68d5f9cb37844ecbd793632944f4459",
+      "port_id": "7095d432-a007-4d6b-9549-683cd1566188",
+      "id": "530e2826-ae43-4cde-bd7c-856a33a3061d",
+      "qos_policy_id": null
+    },
+    {
+      "router_id": null,
+      "status": "DOWN",
+      "description": "idle",
+      "tags": [],
+      "tenant_id": "d7e88181cd044db188592070ec8bf8b4",
+      "created_at": "2020-03-20T12:14:47Z",
+      "updated_at": "2020-03-20T12:14:47Z",
+      "floating_network_id": "38cc9e61-11fc-4921-843d-80ef249a3710",
+      "fixed_ip_address": null,
+      "floating_ip_address": "10.0.50.8",
+      "revision_number": 0,
+      "project_id": "d7e88181cd044db188592070ec8bf8b4",
+      "port_id": null,
+      "id": "65297c50-2c6e-4c5f-96eb-8b4c228cd54c",
+      "qos_policy_id": null
+    }
+  ]
+}

--- a/core/src/main/java/org/openstack4j/model/network/NetFloatingIP.java
+++ b/core/src/main/java/org/openstack4j/model/network/NetFloatingIP.java
@@ -4,6 +4,9 @@ import org.openstack4j.common.Buildable;
 import org.openstack4j.model.ModelEntity;
 import org.openstack4j.model.network.builder.NetFloatingIPBuilder;
 
+import java.util.Date;
+import java.util.List;
+
 /**
  * The Interface NetFloatingIP.
  * 
@@ -33,6 +36,11 @@ public interface NetFloatingIP extends ModelEntity, Buildable<NetFloatingIPBuild
    */
    String getTenantId();
 
+   /**
+    * Gets the project id.
+    */
+   String getProjectId();
+
   /**
    * Gets the floating network id.
    *
@@ -60,13 +68,41 @@ public interface NetFloatingIP extends ModelEntity, Buildable<NetFloatingIPBuild
    * @return the port id
    */
    String getPortId();
-   
+
    /**
+    * ID of the QoS policy.
+    */
+   String getQosPolicyId();
+
+    /**
     * Gets the floating ip status
     * 
     * @return the floating ip status
     */
    String getStatus();
-   
 
+   /**
+    * Get text description of the resource;
+    */
+   String getDescription();
+
+   /**
+    * List of tags associated with the IP address.
+    */
+   List<String> getTags();
+
+   /**
+    * Time the IP was created.
+    */
+   Date getCreatedAt();
+
+   /**
+    * Time the IP was last updated.
+    */
+   Date getUpdatedAt();
+
+   /**
+    * Revision number of a resource.
+    */
+   Integer getRevisionNumber();
 }

--- a/core/src/main/java/org/openstack4j/model/network/builder/NetFloatingIPBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/network/builder/NetFloatingIPBuilder.java
@@ -9,21 +9,37 @@ import org.openstack4j.model.network.NetFloatingIP;
  * @author Nathan Anderson
  */
 public interface NetFloatingIPBuilder extends Builder<NetFloatingIPBuilder, NetFloatingIP> {
-	
-	/**
-	 * sets Id of floating network
-	 *
-	 * @param networkId the network id
-	 * @return the floating ip builder
-	 */
-	NetFloatingIPBuilder floatingNetworkId(String networkId);
-  
-  /**
-   * Port id.
-   *
-   * @param portId the port id
-   * @return the floating ip builder
-   */
-  NetFloatingIPBuilder portId(String portId);
-	
+
+    /**
+     * sets Id of floating network
+     *
+     * @param networkId the network id
+     * @return the floating ip builder
+     */
+    NetFloatingIPBuilder floatingNetworkId(String networkId);
+
+    /**
+     * Port id.
+     *
+     * @param portId the port id
+     * @return the floating ip builder
+     */
+    NetFloatingIPBuilder portId(String portId);
+
+    /**
+     * Value of the floating IP to use.
+     */
+    NetFloatingIPBuilder floatingIpAddress(String address);
+
+    /**
+     * Fixed IP to connect to.
+     */
+    NetFloatingIPBuilder fixedIpAddress(String address);
+
+    /**
+     * Textual description of the resource.
+     *
+     * @param description Maximum of 250 characters.
+     */
+    NetFloatingIPBuilder description(String description);
 }

--- a/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronFloatingIP.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronFloatingIP.java
@@ -241,8 +241,11 @@ public class NeutronFloatingIP implements NetFloatingIP {
    */
   @Override
   public String toString() {
+    // Report tenantId iff it differs from projectId
+    String distinctTenantId = Objects.equals(tenantId, projectId) ? null : tenantId;
     return MoreObjects.toStringHelper(this).omitNullValues()
-            .add("id", id).add("routerId", routerId).add("projectId", projectId).add("floatingNetworkId", floatingNetworkId)
+            .add("id", id).add("routerId", routerId).add("floatingNetworkId", floatingNetworkId)
+            .add("projectId", projectId).add("tenantId", distinctTenantId)
             .add("floatingIpAddress", floatingIpAddress).add("fixedIpAddress", fixedIpAddress).add("portId", portId).add("status", status)
             .toString();
   }

--- a/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronFloatingIP.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronFloatingIP.java
@@ -1,6 +1,8 @@
 package org.openstack4j.openstack.networking.domain;
 
+import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 
 import org.openstack4j.model.network.NetFloatingIP;
 import org.openstack4j.model.network.builder.NetFloatingIPBuilder;
@@ -29,6 +31,9 @@ public class NeutronFloatingIP implements NetFloatingIP {
   @JsonProperty("tenant_id")
   private String tenantId;
 
+  @JsonProperty("project_id")
+  private String projectId;
+
   @JsonProperty("floating_network_id")
   private String floatingNetworkId;
 
@@ -41,7 +46,23 @@ public class NeutronFloatingIP implements NetFloatingIP {
   @JsonProperty("port_id")
   private String portId;
 
+  @JsonProperty("qos_policy_id")
+  private String qosPolicyId;
+
   private String status;
+
+  private String description;
+
+  private List<String> tags;
+
+  @JsonProperty("created_at")
+  private Date createdAt;
+
+  @JsonProperty("updated_at")
+  private Date updatedAt;
+
+  @JsonProperty("revision_number")
+  private Integer revisionNumber;
 
   /**
    * {@inheritDoc}
@@ -84,6 +105,11 @@ public class NeutronFloatingIP implements NetFloatingIP {
     return this.tenantId;
   }
 
+  @Override
+  public String getProjectId() {
+    return projectId;
+  }
+
   /**
    * {@inheritDoc}
    */
@@ -114,6 +140,16 @@ public class NeutronFloatingIP implements NetFloatingIP {
   @Override
   public String getPortId() {
     return this.portId;
+  }
+
+  @Override
+  public String getQosPolicyId() {
+    return qosPolicyId;
+  }
+
+  @Override
+  public Integer getRevisionNumber() {
+    return revisionNumber;
   }
 
   /**
@@ -180,50 +216,65 @@ public class NeutronFloatingIP implements NetFloatingIP {
 	this.status = status;
   }
 
-/**
+  @Override
+  public String getDescription() {
+    return description;
+  }
+
+  @Override
+  public List<String> getTags() {
+    return tags;
+  }
+
+  @Override
+  public Date getCreatedAt() {
+    return createdAt;
+  }
+
+  @Override
+  public Date getUpdatedAt() {
+    return updatedAt;
+  }
+
+  /**
    * {@inheritDoc}
    */
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this).omitNullValues()
-            .add("id", id).add("routerId", routerId).add("tenantId", tenantId).add("floatingNetworkId", floatingNetworkId)
+            .add("id", id).add("routerId", routerId).add("projectId", projectId).add("floatingNetworkId", floatingNetworkId)
             .add("floatingIpAddress", floatingIpAddress).add("fixedIpAddress", fixedIpAddress).add("portId", portId).add("status", status)
-            .addValue("\n")
             .toString();
   }
 
-  /**
-   * {@inheritDoc}
-   */
   @Override
   public int hashCode() {
-    return java.util.Objects.hash(id, routerId, tenantId, floatingNetworkId,
-            floatingIpAddress, fixedIpAddress, portId, status);
+    return Objects.hash(
+            id, routerId, tenantId, projectId, floatingNetworkId, floatingIpAddress, fixedIpAddress, portId,
+            qosPolicyId, status, description, tags, createdAt, updatedAt, revisionNumber
+    );
   }
 
-  /**
-   * {@inheritDoc}
-   */
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-
-    if (obj instanceof NeutronFloatingIP) {
-      NeutronFloatingIP that = (NeutronFloatingIP) obj;
-      if (java.util.Objects.equals(id, that.id) &&
-              java.util.Objects.equals(routerId, that.routerId) &&
-              java.util.Objects.equals(tenantId, that.tenantId) &&
-              java.util.Objects.equals(floatingNetworkId, that.floatingNetworkId) &&
-              java.util.Objects.equals(floatingIpAddress, that.floatingIpAddress) &&
-              java.util.Objects.equals(fixedIpAddress, that.fixedIpAddress) &&
-              java.util.Objects.equals(portId, that.portId) &&
-              java.util.Objects.equals(status, that.status)) {
-        return true;
-      }
-    }
-    return false;
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    NeutronFloatingIP that = (NeutronFloatingIP) o;
+    return Objects.equals(id, that.id) &&
+            Objects.equals(routerId, that.routerId) &&
+            Objects.equals(tenantId, that.tenantId) &&
+            Objects.equals(projectId, that.projectId) &&
+            Objects.equals(floatingNetworkId, that.floatingNetworkId) &&
+            Objects.equals(floatingIpAddress, that.floatingIpAddress) &&
+            Objects.equals(fixedIpAddress, that.fixedIpAddress) &&
+            Objects.equals(portId, that.portId) &&
+            Objects.equals(qosPolicyId, that.qosPolicyId) &&
+            Objects.equals(status, that.status) &&
+            Objects.equals(description, that.description) &&
+            Objects.equals(tags, that.tags) &&
+            Objects.equals(createdAt, that.createdAt) &&
+            Objects.equals(updatedAt, that.updatedAt) &&
+            Objects.equals(revisionNumber, that.revisionNumber);
   }
 
   /**
@@ -308,7 +359,23 @@ public class NeutronFloatingIP implements NetFloatingIP {
       f.portId = portId;
       return this;
     }
+
+    @Override
+    public NetFloatingIPBuilder floatingIpAddress(String address) {
+      f.floatingIpAddress = address;
+      return this;
+    }
+
+    @Override
+    public NetFloatingIPBuilder fixedIpAddress(String address) {
+      f.fixedIpAddress = address;
+      return this;
+    }
+
+    @Override
+    public NetFloatingIPBuilder description(String description) {
+      f.description = description;
+      return this;
+    }
   }
-
-
 }


### PR DESCRIPTION
Add remaining fields missing in `NetFloatingIP` so all documented fields can be read.

https://docs.openstack.org/api-ref/network/v2/?expanded=list-floating-ips-detail