### PR TITLE
add feature to create a pool with loadbalancerId

### DIFF
--- a/core-test/src/main/java/org/openstack4j/api/network/LbPoolV2Tests.java
+++ b/core-test/src/main/java/org/openstack4j/api/network/LbPoolV2Tests.java
@@ -28,6 +28,7 @@ import static org.testng.Assert.assertTrue;
 public class LbPoolV2Tests extends AbstractTest {
     private static final String LBPOOLSV2_JSON = "/network/lbpoolsv2.json";
     private static final String LBPOOLV2_JSON = "/network/lbpoolv2.json";
+    private static final String LBPOOLV2_WITHOUT_LISTENER_JSON = "/network/lbpoolv2_without_listener.json";
     private static final String LBPOOLV2_UPDATE_JSON = "/network/lbpoolv2_update.json";
 
     public void testListPoolV2() throws IOException {
@@ -69,6 +70,27 @@ public class LbPoolV2Tests extends AbstractTest {
         assertEquals(result.getName(), name);
         assertEquals(result.getLbMethod(), LbMethod.LEAST_CONNECTIONS);
         assertEquals(result.getProtocol(), protocol);
+    }
+
+    public void testCreatePoolV2_no_listener() throws IOException {
+        respondWith(LBPOOLV2_WITHOUT_LISTENER_JSON);
+        String name = "testlbpool_no_listener";
+        Protocol protocol = Protocol.HTTP;
+        String loadbalancerId = "fbc45db6-d3c2-4918-981e-c8ae8c9eccc0";
+        LbPoolV2 create = Builders.lbpoolV2()
+                .adminStateUp(true)
+                .description("im a swimming pool")
+                .lbMethod(LbMethod.LEAST_CONNECTIONS)
+                .name(name)
+                .tenantId("6f759d84e3ca496ab77f8c0ffaa0311e")
+                .protocol(protocol)
+                .loadbalancerId(loadbalancerId)
+                .build();
+        LbPoolV2 result = osv3().networking().lbaasV2().lbPool().create(create);
+        assertEquals(result.getName(), name);
+        assertEquals(result.getLbMethod(), LbMethod.LEAST_CONNECTIONS);
+        assertEquals(result.getProtocol(), protocol);
+        assertEquals(result.getLoadbalancerId(), loadbalancerId);
     }
 
     public void testUpdatePoolV2() throws IOException {

--- a/core-test/src/main/java/org/openstack4j/api/network/LbPoolV2Tests.java
+++ b/core-test/src/main/java/org/openstack4j/api/network/LbPoolV2Tests.java
@@ -90,7 +90,7 @@ public class LbPoolV2Tests extends AbstractTest {
         assertEquals(result.getName(), name);
         assertEquals(result.getLbMethod(), LbMethod.LEAST_CONNECTIONS);
         assertEquals(result.getProtocol(), protocol);
-        assertEquals(result.getLoadbalancerId(), loadbalancerId);
+        assertEquals(result.getLoadBalancerId(), loadbalancerId);
     }
 
     public void testUpdatePoolV2() throws IOException {

--- a/core-test/src/main/java/org/openstack4j/api/network/LbPoolV2Tests.java
+++ b/core-test/src/main/java/org/openstack4j/api/network/LbPoolV2Tests.java
@@ -76,7 +76,7 @@ public class LbPoolV2Tests extends AbstractTest {
         respondWith(LBPOOLV2_WITHOUT_LISTENER_JSON);
         String name = "testlbpool_no_listener";
         Protocol protocol = Protocol.HTTP;
-        String loadbalancerId = "fbc45db6-d3c2-4918-981e-c8ae8c9eccc0";
+        String loadBalancerId = "fbc45db6-d3c2-4918-981e-c8ae8c9eccc0";
         LbPoolV2 create = Builders.lbpoolV2()
                 .adminStateUp(true)
                 .description("im a swimming pool")
@@ -84,13 +84,13 @@ public class LbPoolV2Tests extends AbstractTest {
                 .name(name)
                 .tenantId("6f759d84e3ca496ab77f8c0ffaa0311e")
                 .protocol(protocol)
-                .loadbalancerId(loadbalancerId)
+                .loadBalancerId(loadBalancerId)
                 .build();
         LbPoolV2 result = osv3().networking().lbaasV2().lbPool().create(create);
         assertEquals(result.getName(), name);
         assertEquals(result.getLbMethod(), LbMethod.LEAST_CONNECTIONS);
         assertEquals(result.getProtocol(), protocol);
-        assertEquals(result.getLoadBalancerId(), loadbalancerId);
+        assertEquals(result.getLoadBalancerId(), loadBalancerId);
     }
 
     public void testUpdatePoolV2() throws IOException {

--- a/core-test/src/main/resources/network/lbpoolv2_without_listener.json
+++ b/core-test/src/main/resources/network/lbpoolv2_without_listener.json
@@ -1,0 +1,20 @@
+{
+  "pool": {
+    "lb_algorithm": "LEAST_CONNECTIONS",
+    "protocol": "HTTP",
+    "description": "im a swimming pool",
+    "admin_state_up": true,
+    "tenant_id": "6f759d84e3ca496ab77f8c0ffaa0311e",
+    "session_persistence": null,
+    "healthmonitor_id": "350576d8-5015-4d4e-b73f-23df2397e4c4",
+    "listeners": [
+
+    ],
+    "members": [
+
+    ],
+    "id": "b7f6a49f-ebd8-43c5-b792-5748366eff21",
+    "name": "testlbpool_no_listener",
+    "loadbalancer_id": "fbc45db6-d3c2-4918-981e-c8ae8c9eccc0"
+  }
+}

--- a/core/src/main/java/org/openstack4j/model/network/ext/LbPoolV2.java
+++ b/core/src/main/java/org/openstack4j/model/network/ext/LbPoolV2.java
@@ -64,7 +64,7 @@ public interface LbPoolV2 extends ModelEntity, Buildable<LbPoolV2Builder> {
     /**
      * @return The ID of the load balancer under which this pool will be created.
      */
-    String getLoadbalancerId();
+    String getLoadBalancerId();
 
     /**
      * @return List of members that belong to the pool.

--- a/core/src/main/java/org/openstack4j/model/network/ext/LbPoolV2.java
+++ b/core/src/main/java/org/openstack4j/model/network/ext/LbPoolV2.java
@@ -61,6 +61,10 @@ public interface LbPoolV2 extends ModelEntity, Buildable<LbPoolV2Builder> {
      */
     List<ListItem> getListeners();
 
+    /**
+     * @return The ID of the load balancer under which this pool will be created.
+     */
+    String getLoadbalancerId();
 
     /**
      * @return List of members that belong to the pool.

--- a/core/src/main/java/org/openstack4j/model/network/ext/builder/LbPoolV2Builder.java
+++ b/core/src/main/java/org/openstack4j/model/network/ext/builder/LbPoolV2Builder.java
@@ -10,11 +10,13 @@ import org.openstack4j.model.network.ext.SessionPersistence;
  * A Builder to create a lbpoolV2
  *
  * @author emjburns
+ *
  */
 public interface LbPoolV2Builder extends Buildable.Builder<LbPoolV2Builder, LbPoolV2> {
     /**
-     * @param tenantId Owner of the pool. Only an administrative user can specify a
-     *                 tenant ID other than its own.
+     * @param tenantId
+     *            Owner of the pool. Only an administrative user can specify a
+     *            tenant ID other than its own.
      * @return LbPoolV2Builder
      */
     LbPoolV2Builder tenantId(String tenantId);
@@ -22,7 +24,8 @@ public interface LbPoolV2Builder extends Buildable.Builder<LbPoolV2Builder, LbPo
     /**
      * Optional
      *
-     * @param name Pool name. Does not have to be unique.
+     * @param name
+     *            Pool name. Does not have to be unique.
      * @return LbPoolV2Builder
      */
     LbPoolV2Builder name(String name);
@@ -30,24 +33,27 @@ public interface LbPoolV2Builder extends Buildable.Builder<LbPoolV2Builder, LbPo
     /**
      * Optional
      *
-     * @param description Description for the pool.
+     * @param description
+     *            Description for the pool.
      * @return LbPoolV2Builder
      */
     LbPoolV2Builder description(String description);
 
     /**
-     * @param protocol The protocol of the VIP address. A valid value is TCP, HTTP,
-     *                 or HTTPS.
+     * @param protocol
+     *            The protocol of the VIP address. A valid value is TCP, HTTP,
+     *            or HTTPS.
      * @return LbPoolV2Builder
      */
     LbPoolV2Builder protocol(Protocol protocol);
 
     /**
-     * @param lbMethod The load-balancer algorithm, which is round-robin,
-     *                 least-connections, and so on. This value, which must be
-     *                 supported, is dependent on the load-balancer provider. Round
-     *                 robin must be supported.
-     *                 Must be one of ROUND_ROBIN, LEAST_CONNECTIONS, or SOURCE_IP.
+     * @param lbMethod
+     *            The load-balancer algorithm, which is round-robin,
+     *            least-connections, and so on. This value, which must be
+     *            supported, is dependent on the load-balancer provider. Round
+     *            robin must be supported.
+     *            Must be one of ROUND_ROBIN, LEAST_CONNECTIONS, or SOURCE_IP.
      * @return LbPoolV2Builder
      */
     LbPoolV2Builder lbMethod(LbMethod lbMethod);
@@ -55,7 +61,8 @@ public interface LbPoolV2Builder extends Buildable.Builder<LbPoolV2Builder, LbPo
     /**
      * Optional
      *
-     * @param sessionPersistence Default value empty dictionary
+     * @param sessionPersistence
+     *            Default value empty dictionary
      * @return LbPoolV2Builder
      */
     LbPoolV2Builder sessionPersistence(SessionPersistence sessionPersistence);
@@ -63,8 +70,9 @@ public interface LbPoolV2Builder extends Buildable.Builder<LbPoolV2Builder, LbPo
     /**
      * Optional
      *
-     * @param adminStateUp The administrative state of the lb pool, which is up (true) or
-     *                     down (false). Default value true.
+     * @param adminStateUp
+     *            The administrative state of the lb pool, which is up (true) or
+     *            down (false). Default value true.
      * @return LbPoolV2Builder
      */
     LbPoolV2Builder adminStateUp(boolean adminStateUp);
@@ -72,7 +80,6 @@ public interface LbPoolV2Builder extends Buildable.Builder<LbPoolV2Builder, LbPo
     /**
      * The listener in which this pool will become the default pool.
      * There can only be on default pool for a listener.
-     *
      * @param listenerId
      * @return LbPoolV2Builder
      */

--- a/core/src/main/java/org/openstack4j/model/network/ext/builder/LbPoolV2Builder.java
+++ b/core/src/main/java/org/openstack4j/model/network/ext/builder/LbPoolV2Builder.java
@@ -10,13 +10,11 @@ import org.openstack4j.model.network.ext.SessionPersistence;
  * A Builder to create a lbpoolV2
  *
  * @author emjburns
- *
  */
 public interface LbPoolV2Builder extends Buildable.Builder<LbPoolV2Builder, LbPoolV2> {
     /**
-     * @param tenantId
-     *            Owner of the pool. Only an administrative user can specify a
-     *            tenant ID other than its own.
+     * @param tenantId Owner of the pool. Only an administrative user can specify a
+     *                 tenant ID other than its own.
      * @return LbPoolV2Builder
      */
     LbPoolV2Builder tenantId(String tenantId);
@@ -24,8 +22,7 @@ public interface LbPoolV2Builder extends Buildable.Builder<LbPoolV2Builder, LbPo
     /**
      * Optional
      *
-     * @param name
-     *            Pool name. Does not have to be unique.
+     * @param name Pool name. Does not have to be unique.
      * @return LbPoolV2Builder
      */
     LbPoolV2Builder name(String name);
@@ -33,27 +30,24 @@ public interface LbPoolV2Builder extends Buildable.Builder<LbPoolV2Builder, LbPo
     /**
      * Optional
      *
-     * @param description
-     *            Description for the pool.
+     * @param description Description for the pool.
      * @return LbPoolV2Builder
      */
     LbPoolV2Builder description(String description);
 
     /**
-     * @param protocol
-     *            The protocol of the VIP address. A valid value is TCP, HTTP,
-     *            or HTTPS.
+     * @param protocol The protocol of the VIP address. A valid value is TCP, HTTP,
+     *                 or HTTPS.
      * @return LbPoolV2Builder
      */
     LbPoolV2Builder protocol(Protocol protocol);
 
     /**
-     * @param lbMethod
-     *            The load-balancer algorithm, which is round-robin,
-     *            least-connections, and so on. This value, which must be
-     *            supported, is dependent on the load-balancer provider. Round
-     *            robin must be supported.
-     *            Must be one of ROUND_ROBIN, LEAST_CONNECTIONS, or SOURCE_IP.
+     * @param lbMethod The load-balancer algorithm, which is round-robin,
+     *                 least-connections, and so on. This value, which must be
+     *                 supported, is dependent on the load-balancer provider. Round
+     *                 robin must be supported.
+     *                 Must be one of ROUND_ROBIN, LEAST_CONNECTIONS, or SOURCE_IP.
      * @return LbPoolV2Builder
      */
     LbPoolV2Builder lbMethod(LbMethod lbMethod);
@@ -61,8 +55,7 @@ public interface LbPoolV2Builder extends Buildable.Builder<LbPoolV2Builder, LbPo
     /**
      * Optional
      *
-     * @param sessionPersistence
-     *            Default value empty dictionary
+     * @param sessionPersistence Default value empty dictionary
      * @return LbPoolV2Builder
      */
     LbPoolV2Builder sessionPersistence(SessionPersistence sessionPersistence);
@@ -70,9 +63,8 @@ public interface LbPoolV2Builder extends Buildable.Builder<LbPoolV2Builder, LbPo
     /**
      * Optional
      *
-     * @param adminStateUp
-     *            The administrative state of the lb pool, which is up (true) or
-     *            down (false). Default value true.
+     * @param adminStateUp The administrative state of the lb pool, which is up (true) or
+     *                     down (false). Default value true.
      * @return LbPoolV2Builder
      */
     LbPoolV2Builder adminStateUp(boolean adminStateUp);
@@ -80,8 +72,19 @@ public interface LbPoolV2Builder extends Buildable.Builder<LbPoolV2Builder, LbPo
     /**
      * The listener in which this pool will become the default pool.
      * There can only be on default pool for a listener.
+     *
      * @param listenerId
      * @return LbPoolV2Builder
      */
     LbPoolV2Builder listenerId(String listenerId);
+
+    /**
+     * The ID of the load balancer under which this pool will be created.
+     * Each load balancer can have zero or more pools associated with it. These pools can be used for L7policies.
+     * Either listener_id or loadbalancer_id must be specified.
+     *
+     * @param loadbalancerId
+     * @return LbPoolV2Builder
+     */
+    LbPoolV2Builder loadbalancerId(String loadbalancerId);
 }

--- a/core/src/main/java/org/openstack4j/model/network/ext/builder/LbPoolV2Builder.java
+++ b/core/src/main/java/org/openstack4j/model/network/ext/builder/LbPoolV2Builder.java
@@ -90,8 +90,8 @@ public interface LbPoolV2Builder extends Buildable.Builder<LbPoolV2Builder, LbPo
      * Each load balancer can have zero or more pools associated with it. These pools can be used for L7policies.
      * Either listener_id or loadbalancer_id must be specified.
      *
-     * @param loadbalancerId
+     * @param loadBalancerId
      * @return LbPoolV2Builder
      */
-    LbPoolV2Builder loadbalancerId(String loadbalancerId);
+    LbPoolV2Builder loadBalancerId(String loadBalancerId);
 }

--- a/core/src/main/java/org/openstack4j/openstack/networking/domain/ext/NeutronLbPoolV2.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/domain/ext/NeutronLbPoolV2.java
@@ -46,6 +46,9 @@ public class NeutronLbPoolV2 implements LbPoolV2 {
     @JsonProperty("listener_id")
     private String listenerId;
 
+    @JsonProperty("loadbalancer_id")
+    private String loadbalancerId;
+
     private List<ListItem> listeners;
 
     private List<ListItem> members;
@@ -138,6 +141,14 @@ public class NeutronLbPoolV2 implements LbPoolV2 {
      * {@inheritDoc}
      */
     @Override
+    public String getLoadbalancerId(){
+        return loadbalancerId;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public List<ListItem> getMembers(){
         return members;
     }
@@ -163,6 +174,7 @@ public class NeutronLbPoolV2 implements LbPoolV2 {
                 .add("adminStateUp", adminStateUp)
                 .add("listenerId", listenerId)
                 .add("listeners", listeners)
+                .add("loadbalancer", loadbalancerId)
                 .add("members", members)
                 .add("healthMonitorId", healthMonitorId)
                 .toString();
@@ -260,6 +272,15 @@ public class NeutronLbPoolV2 implements LbPoolV2 {
         @Override
         public LbPoolV2Builder listenerId(String listenerId){
             m.listenerId = listenerId;
+            return this;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public LbPoolV2Builder loadbalancerId(String loadbalancerId) {
+            m.loadbalancerId = loadbalancerId;
             return this;
         }
     }

--- a/core/src/main/java/org/openstack4j/openstack/networking/domain/ext/NeutronLbPoolV2.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/domain/ext/NeutronLbPoolV2.java
@@ -47,7 +47,7 @@ public class NeutronLbPoolV2 implements LbPoolV2 {
     private String listenerId;
 
     @JsonProperty("loadbalancer_id")
-    private String loadbalancerId;
+    private String loadBalancerId;
 
     private List<ListItem> listeners;
 
@@ -142,7 +142,7 @@ public class NeutronLbPoolV2 implements LbPoolV2 {
      */
     @Override
     public String getLoadBalancerId(){
-        return loadbalancerId;
+        return loadBalancerId;
     }
 
     /**
@@ -174,7 +174,7 @@ public class NeutronLbPoolV2 implements LbPoolV2 {
                 .add("adminStateUp", adminStateUp)
                 .add("listenerId", listenerId)
                 .add("listeners", listeners)
-                .add("loadbalancerId", loadbalancerId)
+                .add("loadBalancerId", loadBalancerId)
                 .add("members", members)
                 .add("healthMonitorId", healthMonitorId)
                 .toString();
@@ -279,8 +279,8 @@ public class NeutronLbPoolV2 implements LbPoolV2 {
          * {@inheritDoc}
          */
         @Override
-        public LbPoolV2Builder loadbalancerId(String loadbalancerId) {
-            m.loadbalancerId = loadbalancerId;
+        public LbPoolV2Builder loadBalancerId(String loadBalancerId) {
+            m.loadBalancerId = loadBalancerId;
             return this;
         }
     }

--- a/core/src/main/java/org/openstack4j/openstack/networking/domain/ext/NeutronLbPoolV2.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/domain/ext/NeutronLbPoolV2.java
@@ -141,7 +141,7 @@ public class NeutronLbPoolV2 implements LbPoolV2 {
      * {@inheritDoc}
      */
     @Override
-    public String getLoadbalancerId(){
+    public String getLoadBalancerId(){
         return loadbalancerId;
     }
 

--- a/core/src/main/java/org/openstack4j/openstack/networking/domain/ext/NeutronLbPoolV2.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/domain/ext/NeutronLbPoolV2.java
@@ -174,7 +174,7 @@ public class NeutronLbPoolV2 implements LbPoolV2 {
                 .add("adminStateUp", adminStateUp)
                 .add("listenerId", listenerId)
                 .add("listeners", listeners)
-                .add("loadbalancer", loadbalancerId)
+                .add("loadbalancerId", loadbalancerId)
                 .add("members", members)
                 .add("healthMonitorId", healthMonitorId)
                 .toString();


### PR DESCRIPTION
add feature to create a pool with loadbalancerId, without a listener.
the purpose is to implement openstack pool API: Either listener_id or loadbalancer_id must be specified when creating pool.

refer to openstack API doc:
[https://docs.openstack.org/api-ref/load-balancer/v2/?expanded=create-pool-detail](https://docs.openstack.org/api-ref/load-balancer/v2/?expanded=create-pool-detail)
