### PR TITLE
 Fixed case-sensitiveness in metadata headers detection

### DIFF
--- a/core/src/main/java/org/openstack4j/openstack/storage/object/functions/MapWithoutMetaPrefixFunction.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/object/functions/MapWithoutMetaPrefixFunction.java
@@ -21,11 +21,11 @@ public class MapWithoutMetaPrefixFunction implements Function<Map<String, String
         	  if (key == null) {
         	  	continue;
         	  }
-            int idx = key.indexOf("-Meta-");
+            int idx = key.toLowerCase().indexOf("-meta-");
             if (idx > -1) {
                 metadata.put(key.substring(idx + 6), input.get(key));
             }
-            if (key.indexOf("X-") > -1) {
+            if (key.toLowerCase().indexOf("x-") > -1) {
                 metadata.put(key, input.get(key));
             }
         }

--- a/core/src/test/java/org/openstack4j/test/common/MapWithoutMetaPrefixFunctionTest.java
+++ b/core/src/test/java/org/openstack4j/test/common/MapWithoutMetaPrefixFunctionTest.java
@@ -1,0 +1,42 @@
+package org.openstack4j.test.common;
+
+import com.google.common.collect.ImmutableMap;
+import org.openstack4j.openstack.storage.object.functions.MapWithoutMetaPrefixFunction;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests HeaderNameValue based transformation
+ * 
+ * @author Jeremy Unruh
+ *
+ */
+public class MapWithoutMetaPrefixFunctionTest {
+
+    private static Map<String, String> VALUES = ImmutableMap.of(
+        "X-Meta-Value1", "Value1",
+        "X-Meta-Value2", "value2",
+        "x-meta-value3", "Value3",
+        "x-meta-value4", "value4" // Test case-sensitiveness of X- or -Meta- detection to be RFC-compliant
+    );
+
+    @Test
+    public void keyTest() {
+        Map<String, String> map = MapWithoutMetaPrefixFunction.INSTANCE.apply(VALUES);
+        for (String key : VALUES.keySet()) {
+            assertTrue(map.containsKey(key));
+        }
+    }
+
+    @Test
+    public void valueTest() {
+        Map<String, String> map = MapWithoutMetaPrefixFunction.INSTANCE.apply(VALUES);
+        for (String value : VALUES.values()) {
+            assertTrue(map.containsValue(value));
+        }
+    }
+
+}


### PR DESCRIPTION
I am facing issue with reverse proxies forcing header names to lowercase to enforce HTTP/2.0 compliance. After referring to the RFC documentation for 1.1 (https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2), I realized that even at that standard, Header field names should be case-insensitive.

As a result, I forced the field name into lower-case for comparison (indexOf being case-sensitive) and added some unit tests to validate the behavior.

* Fixed case-sensitiveness in Swift metadata headers detection
* Added tests for MapWithoutMetaPrefixFunction.java