### PR TITLE
fix https://github.com/openstack4j/openstack4j/issues/65

### DIFF
--- a/core/src/main/java/org/openstack4j/openstack/identity/internal/DefaultEndpointURLResolver.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/internal/DefaultEndpointURLResolver.java
@@ -132,7 +132,7 @@ public class DefaultEndpointURLResolver implements EndpointURLResolver {
         }
 
         for (org.openstack4j.model.identity.v3.Service service : token.getCatalog()) {
-            if (p.type == ServiceType.forName(service.getType()) || p.type == ServiceType.forName(service.getName())) {
+            if (p.type == ServiceType.forName(service.getType()) && p.type == ServiceType.forName(service.getName())) {
                 if (p.perspective == null) {
                     p.perspective = Facing.PUBLIC;
                 }


### PR DESCRIPTION
This PR slightly modifies the DefaultEndpointURLResolver to select a service endpoint for a given service type  when the type **and** the name matches.