### PR TITLE
Avoid MismatchedInputException when reading KeystoneProject from JSON

### DIFF
--- a/core-test/src/main/java/org/openstack4j/api/identity/v3/KeystoneProjectServiceTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/identity/v3/KeystoneProjectServiceTests.java
@@ -23,6 +23,7 @@ public class KeystoneProjectServiceTests extends AbstractTest {
     private static final String JSON_PROJECTS_UPDATE = "/identity/v3/projects_update_response.json";
     private static final String JSON_PROJECTS_GET_BYID = "/identity/v3/projects_get_byId.json";
     private static final String JSON_PROJECTS_GET_BY_NAME_EMPTY = "/identity/v3/projects_getByName_empty.json";
+    private static final String JSON_PROJECTS_WITH_EXTRA = "/identity/v3/projects_with_extra.json";
     private static final String PROJECT_NAME = "ProjectX";
     private static final String PROJECT_DOMAIN_ID = "7a71863c2d1d4444b3e6c2cd36955e1e";
     private static final String PROJECT_DESCRIPTION = "Project used for CRUD tests";
@@ -31,6 +32,7 @@ public class KeystoneProjectServiceTests extends AbstractTest {
     private static final String PROJECT_EXTRA_VALUE_1 = "value1";
     private static final String PROJECT_EXTRA_KEY_2 = "extra_key2";
     private static final String PROJECT_EXTRA_VALUE_2 = "value2";
+    private static final String PROJECT_EXTRA_KEY_TO_BE_IGNORED = "extra_key_to_be_ignored";
     private static final List<String> TAGS = Arrays.asList("one", "two", "three");
 
     @Override
@@ -101,5 +103,16 @@ public class KeystoneProjectServiceTests extends AbstractTest {
         Project project = list.stream().filter(p -> "demo".equals(p.getName())).findFirst().get();
         assertEquals(project.getId(), "600905d353a84b20b644d2fe55a21e8a");
         assertEquals(project.getOptions(), Collections.emptyMap());
+    }
+
+    @Test
+    public void project_with_extra() throws IOException {
+        respondWith(JSON_PROJECTS_WITH_EXTRA);
+        List<? extends Project> projects = osv3().identity().projects().list();
+        assertEquals(projects.size(), 2);
+        Project project = projects.stream().filter(p -> "demo".equals(p.getName())).findFirst().get();
+        assertEquals(project.getExtra(PROJECT_EXTRA_KEY_1), PROJECT_EXTRA_VALUE_1);
+        assertEquals(project.getExtra(PROJECT_EXTRA_KEY_2), PROJECT_EXTRA_VALUE_2);
+        assertNull(project.getExtra(PROJECT_EXTRA_KEY_TO_BE_IGNORED));
     }
 }

--- a/core-test/src/main/resources/identity/v3/projects_with_extra.json
+++ b/core-test/src/main/resources/identity/v3/projects_with_extra.json
@@ -1,0 +1,43 @@
+{
+  "links": {
+    "self": "http://127.0.0.1:5000/v3/projects",
+    "previous": null,
+    "next": null
+  },
+  "projects": [
+    {
+      "is_domain": false,
+      "description": "demo openstack services",
+      "links": {
+        "self": "http://127.0.0.1:5000/v3/projects/600905d353a84b20b644d2fe55a21e8a"
+      },
+      "tags": [],
+      "enabled": true,
+      "id": "600905d353a84b20b644d2fe55a21e8a",
+      "parent_id": "default",
+      "options": {},
+      "domain_id": "default",
+      "name": "demo",
+      "extra_key_to_be_ignored": [],
+      "extra_key1": "value1",
+      "extra_key2": "value2"
+    },
+    {
+      "is_domain": false,
+      "description": "admin openstack services",
+      "links": {
+        "self": "http://127.0.0.1:5000/v3/projects/8519dba9f4594f0f87071c87784a8d2c"
+      },
+      "tags": [],
+      "enabled": true,
+      "id": "8519dba9f4594f0f87071c87784a8d2c",
+      "parent_id": "default",
+      "options": {},
+      "domain_id": "default",
+      "name": "admin",
+      "extra_key_to_be_ignored": [],
+      "extra_key1": "value1",
+      "extra_key2": "value2"
+    }
+  ]
+}

--- a/core/src/main/java/org/openstack4j/openstack/identity/v3/domain/KeystoneProject.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/v3/domain/KeystoneProject.java
@@ -175,13 +175,16 @@ public class KeystoneProject implements Project {
     }
 
     @JsonAnySetter
-    public void setExtra(String key, String value) {
+    public void setExtra(String key, Object value) {
         // is_domain is not necessary
         // if we don't ignore this, this will be set into extra field.
         if (Objects.equal(key, "is_domain")) {
             return;
         }
-        extra.put(key, value);
+
+        if (value instanceof String) {
+            extra.put(key, (String) value);
+        }
     }
 
     /**


### PR DESCRIPTION
Avoid MismatchedInputException when reading KeystoneProject from JSON

related to [#1299](https://github.com/ContainX/openstack4j/issues/1299)