### PR TITLE
Support allowed address pairs on port creation

### DIFF
--- a/core-test/src/main/java/org/openstack4j/api/network/PortTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/network/PortTests.java
@@ -42,6 +42,10 @@ public class PortTests extends AbstractTest {
         assertEquals(port.getNetworkId(), NETWORK_ID);
         assertEquals(port.getCreatedTime(), DATE);
         assertEquals(port.getUpdatedTime(), DATE);
+        
+        AllowedAddressPair allowedAddressPair = port.getAllowedAddressPairs().iterator().next();
+        assertNotNull(allowedAddressPair.getIpAddress());
+        assertNotNull(allowedAddressPair.getMacAddress());
     }
 
     private Port getPort() {

--- a/core-test/src/main/java/org/openstack4j/api/network/PortTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/network/PortTests.java
@@ -6,9 +6,11 @@ import java.util.List;
 
 import org.openstack4j.api.AbstractTest;
 import org.openstack4j.api.Builders;
+import org.openstack4j.model.network.AllowedAddressPair;
 import org.openstack4j.model.network.Port;
 import org.testng.annotations.Test;
 
+import static org.junit.Assert.assertNotNull;
 import static org.testng.Assert.assertEquals;
 
 /**

--- a/core-test/src/main/resources/network/port_external.json
+++ b/core-test/src/main/resources/network/port_external.json
@@ -14,10 +14,12 @@
         "binding:vnic_type": "baremetal",
         "device_id": "d90a13da-be41-461f-9f99-1dbcf438fdf2",
         "device_owner": "baremetal:none",
-        "allowed_address_pairs": [{
-        	"ip_address": "192.168.0.100",
-        	"mac_address": "00:60:2f:38:62:8d"
-        }],
+        "allowed_address_pairs": [
+            {
+                "ip_address": "192.168.0.100",
+                "mac_address": "00:60:2f:38:62:8d"
+            }
+        ],
         "created_at": "2020-10-30T22:16:01Z",
         "updated_at": "2020-10-30T22:16:01Z"
     }

--- a/core-test/src/main/resources/network/port_external.json
+++ b/core-test/src/main/resources/network/port_external.json
@@ -14,6 +14,10 @@
         "binding:vnic_type": "baremetal",
         "device_id": "d90a13da-be41-461f-9f99-1dbcf438fdf2",
         "device_owner": "baremetal:none",
+        "allowed_address_pairs": [{
+        	"ip_address": "192.168.0.100",
+        	"mac_address": "00:60:2f:38:62:8d"
+        }],
         "created_at": "2020-10-30T22:16:01Z",
         "updated_at": "2020-10-30T22:16:01Z"
     }

--- a/core-test/src/main/resources/network/ports_external.json
+++ b/core-test/src/main/resources/network/ports_external.json
@@ -2,7 +2,6 @@
     "ports": [
         {
             "admin_state_up": false,
-            "allowed_address_pairs": [],
             "data_plane_status": null,
             "description": "",
             "device_id": "",
@@ -13,10 +12,12 @@
                     "subnet_id": "a0304c3a-4f08-4c43-88af-d796509c97d2"
                 }
             ],
-	        "allowed_address_pairs": [{
-	        	"ip_address": "192.168.0.100",
-	        	"mac_address": "00:60:2f:38:62:8d"
-	        }],
+            "allowed_address_pairs": [
+                {
+                    "ip_address": "192.168.0.100",
+                    "mac_address": "00:60:2f:38:62:8d"
+                }
+            ],
             "id": "94225baa-9d3f-4b93-bf12-b41e7ce49cdb",
             "mac_address": "fa:16:3e:48:b8:9f",
             "name": "sample_port_1",
@@ -32,7 +33,6 @@
         },
         {
             "admin_state_up": false,
-            "allowed_address_pairs": [],
             "data_plane_status": null,
             "description": "",
             "device_id": "",
@@ -43,10 +43,12 @@
                     "subnet_id": "a0304c3a-4f08-4c43-88af-d796509c97d2"
                 }
             ],
-	        "allowed_address_pairs": [{
-	        	"ip_address": "192.168.0.101",
-	        	"mac_address": "fa:16:3e:f4:73:df"
-	        }],
+            "allowed_address_pairs": [
+                {
+                    "ip_address": "192.168.0.101",
+                    "mac_address": "fa:16:3e:f4:73:df"
+                }
+            ],
             "id": "235b09e0-63c4-47f1-b221-66ba54c21760",
             "mac_address": "fa:16:3e:f4:73:df",
             "name": "sample_port_2",

--- a/core-test/src/main/resources/network/ports_external.json
+++ b/core-test/src/main/resources/network/ports_external.json
@@ -13,6 +13,10 @@
                     "subnet_id": "a0304c3a-4f08-4c43-88af-d796509c97d2"
                 }
             ],
+	        "allowed_address_pairs": [{
+	        	"ip_address": "192.168.0.100",
+	        	"mac_address": "00:60:2f:38:62:8d"
+	        }],
             "id": "94225baa-9d3f-4b93-bf12-b41e7ce49cdb",
             "mac_address": "fa:16:3e:48:b8:9f",
             "name": "sample_port_1",
@@ -39,6 +43,10 @@
                     "subnet_id": "a0304c3a-4f08-4c43-88af-d796509c97d2"
                 }
             ],
+	        "allowed_address_pairs": [{
+	        	"ip_address": "192.168.0.101",
+	        	"mac_address": "fa:16:3e:f4:73:df"
+	        }],
             "id": "235b09e0-63c4-47f1-b221-66ba54c21760",
             "mac_address": "fa:16:3e:f4:73:df",
             "name": "sample_port_2",

--- a/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronPortCreate.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronPortCreate.java
@@ -30,6 +30,9 @@ public class NeutronPortCreate implements ModelEntity {
 
     @JsonProperty("fixed_ips")
     private Set<NeutronIP> fixedIps;
+    
+    @JsonProperty("allowed_address_pairs")
+    private Set<NeutronAllowedAddressPair> allowedAddressPairs;
 
     @JsonProperty("mac_address")
     private String macAddress;
@@ -89,6 +92,7 @@ public class NeutronPortCreate implements ModelEntity {
         c.deviceOwner = port.getDeviceOwner();
         c.securityGroups = port.getSecurityGroups();
         c.fixedIps = (Set<NeutronIP>) port.getFixedIps();
+        c.allowedAddressPairs = (Set<NeutronAllowedAddressPair>) port.getAllowedAddressPairs();
         c.portSecurityEnabled = port.isPortSecurityEnabled();
         c.hostId = port.getHostId();
         c.vifType = port.getVifType();


### PR DESCRIPTION
# PR description

Neutron: Support allowed address pairs on port creation.
API Doc: https://docs.openstack.org/api-ref/network/v2/?expanded=create-port-detail#create-port

## Submitter checklist

Make sure that following is addressed to make the PR easier to process:

- [x] If applicable, changes are covered by either a unit or a functional test.
- [x] If applicable, changes ware verified manually against an OpenStack instance.
- [x] If the change is API related, the PR description links to OpenStack API documentation of that particular endpoint/request (https://docs.openstack.org/api-quick-start/#current-api-versions).
- [x] If the change concerns particular OpenStack service, its name is used as a PR name prefix (ex.: "Neutron: Add floatingIp port forwardings service").
- [ ] If the PR closes existing GitHub issue, PR name have prefix: `Fix #NNN: `.
