### PR TITLE
Neutron: Support allowed address pairs on port creation

### DIFF
--- a/core-test/src/main/java/org/openstack4j/api/network/PortTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/network/PortTests.java
@@ -1,15 +1,17 @@
 package org.openstack4j.api.network;
 
+import static org.junit.Assert.assertNotNull;
+import static org.testng.Assert.assertEquals;
+
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
 import org.openstack4j.api.AbstractTest;
 import org.openstack4j.api.Builders;
+import org.openstack4j.model.network.AllowedAddressPair;
 import org.openstack4j.model.network.Port;
 import org.testng.annotations.Test;
-
-import static org.testng.Assert.assertEquals;
 
 /**
  * @author Rizwan Qamar
@@ -42,6 +44,10 @@ public class PortTests extends AbstractTest {
         assertEquals(port.getNetworkId(), NETWORK_ID);
         assertEquals(port.getCreatedTime(), DATE);
         assertEquals(port.getUpdatedTime(), DATE);
+        
+        AllowedAddressPair allowedAddressPair = port.getAllowedAddressPairs().iterator().next();
+        assertNotNull(allowedAddressPair.getIpAddress());
+        assertNotNull(allowedAddressPair.getMacAddress());        
     }
 
     private Port getPort() {

--- a/core-test/src/main/resources/network/port_external.json
+++ b/core-test/src/main/resources/network/port_external.json
@@ -14,6 +14,12 @@
         "binding:vnic_type": "baremetal",
         "device_id": "d90a13da-be41-461f-9f99-1dbcf438fdf2",
         "device_owner": "baremetal:none",
+        "allowed_address_pairs": [
+            {
+                   "ip_address": "192.168.0.100",
+                   "mac_address": "00:60:2f:38:62:8d"
+            }
+        ],
         "created_at": "2020-10-30T22:16:01Z",
         "updated_at": "2020-10-30T22:16:01Z"
     }

--- a/core-test/src/main/resources/network/ports_external.json
+++ b/core-test/src/main/resources/network/ports_external.json
@@ -2,7 +2,6 @@
     "ports": [
         {
             "admin_state_up": false,
-            "allowed_address_pairs": [],
             "data_plane_status": null,
             "description": "",
             "device_id": "",
@@ -11,6 +10,12 @@
                 {
                     "ip_address": "10.0.0.5",
                     "subnet_id": "a0304c3a-4f08-4c43-88af-d796509c97d2"
+                }
+            ],
+            "allowed_address_pairs": [
+                {
+                       "ip_address": "192.168.0.100",
+                       "mac_address": "00:60:2f:38:62:8d"
                 }
             ],
             "id": "94225baa-9d3f-4b93-bf12-b41e7ce49cdb",
@@ -28,7 +33,6 @@
         },
         {
             "admin_state_up": false,
-            "allowed_address_pairs": [],
             "data_plane_status": null,
             "description": "",
             "device_id": "",
@@ -37,6 +41,12 @@
                 {
                     "ip_address": "10.0.0.6",
                     "subnet_id": "a0304c3a-4f08-4c43-88af-d796509c97d2"
+                }
+            ],
+            "allowed_address_pairs": [
+                {
+                       "ip_address": "192.168.0.101",
+                       "mac_address": "fa:16:3e:f4:73:df"
                 }
             ],
             "id": "235b09e0-63c4-47f1-b221-66ba54c21760",

--- a/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronPortCreate.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronPortCreate.java
@@ -33,7 +33,10 @@ public class NeutronPortCreate implements ModelEntity {
 
     @JsonProperty("mac_address")
     private String macAddress;
-
+    
+    @JsonProperty("allowed_address_pairs")
+    private Set<NeutronAllowedAddressPair> allowedAddressPairs;
+    
     @JsonProperty("network_id")
     private String networkId;
 
@@ -89,6 +92,7 @@ public class NeutronPortCreate implements ModelEntity {
         c.deviceOwner = port.getDeviceOwner();
         c.securityGroups = port.getSecurityGroups();
         c.fixedIps = (Set<NeutronIP>) port.getFixedIps();
+        c.allowedAddressPairs = (Set<NeutronAllowedAddressPair>) port.getAllowedAddressPairs();
         c.portSecurityEnabled = port.isPortSecurityEnabled();
         c.hostId = port.getHostId();
         c.vifType = port.getVifType();


### PR DESCRIPTION
# PR description

Neutron: Support allowed address pairs on port creation.
API Doc: https://docs.openstack.org/api-ref/network/v2/?expanded=create-port-detail#create-port

## Submitter checklist

Make sure that following is addressed to make the PR easier to process:

- [x] If applicable, changes are covered by either a unit or a functional test.
- [x] If applicable, changes ware verified manually against an OpenStack instance.
- [x] If the change is API related, the PR description links to OpenStack API documentation of that particular endpoint/request (https://docs.openstack.org/api-quick-start/#current-api-versions).
- [x] If the change concerns particular OpenStack service, its name is used as a PR name prefix (ex.: "Neutron: Add floatingIp port forwardings service").
- [ ] If the PR closes existing GitHub issue, PR name have prefix: `Fix #NNN: `.
