### PR TITLE
Neutron: Add subnetpool and RBAC policy to quota

### DIFF
--- a/core-test/src/main/java/org/openstack4j/api/network/NetQuotaTest.java
+++ b/core-test/src/main/java/org/openstack4j/api/network/NetQuotaTest.java
@@ -25,6 +25,8 @@ public class NetQuotaTest extends AbstractTest {
         assertEquals(14, netQuota.getFloatingIP());
         assertEquals(15, netQuota.getSecurityGroup());
         assertEquals(16, netQuota.getSecurityGroupRule());
+        assertEquals(17, netQuota.getSubnetpool());
+        assertEquals(18, netQuota.getRbacPolicy());
     }
 
     @Override

--- a/core-test/src/main/resources/network/quota.json
+++ b/core-test/src/main/resources/network/quota.json
@@ -6,6 +6,8 @@
         "network": 13,
         "floatingip": 14,
         "security_group": 15,
-        "security_group_rule": 16
+        "security_group_rule": 16,
+        "subnetpool": 17,
+        "rbac_policy": 18
     }
 }

--- a/core/src/main/java/org/openstack4j/model/network/NetQuota.java
+++ b/core/src/main/java/org/openstack4j/model/network/NetQuota.java
@@ -59,4 +59,18 @@ public interface NetQuota extends ModelEntity, Buildable<NetQuotaBuilder> {
      * @return number of security groups rules
      */
     int getSecurityGroupRule();
+    
+    /**
+     * The number of subnet pools allowed for each project. A value of -1 means no limit
+     *
+     * @return number of subnet pools
+     */
+    int getSubnetpool();
+
+    /**
+     * The number of role-based access control (RBAC) policies for each project. A value of -1 means no limit
+     *
+     * @return number of RBAC policies
+     */
+    int getRbacPolicy();
 }

--- a/core/src/main/java/org/openstack4j/model/network/builder/NetQuotaBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/network/builder/NetQuotaBuilder.java
@@ -73,7 +73,7 @@ public interface NetQuotaBuilder extends Builder<NetQuotaBuilder, NetQuota> {
      * @param rbacPolicy
      * @return NetQuotaBuilder
      */
-    NetQuotaBuilder rbacPolicy(Integer rbacPolicy);
+    NetQuotaBuilder rbacPolicy(int rbacPolicy);
 
     /**
      * See {@link NetQuota#getSubnetPool()} for details
@@ -81,5 +81,5 @@ public interface NetQuotaBuilder extends Builder<NetQuotaBuilder, NetQuota> {
      * @param subnetPool
      * @return NetQuotaBuilder
      */
-    NetQuotaBuilder subnetpool(Integer subnetpool);
+    NetQuotaBuilder subnetpool(int subnetpool);
 }

--- a/core/src/main/java/org/openstack4j/model/network/builder/NetQuotaBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/network/builder/NetQuotaBuilder.java
@@ -66,4 +66,20 @@ public interface NetQuotaBuilder extends Builder<NetQuotaBuilder, NetQuota> {
      */
     NetQuotaBuilder securityGroupRule(int securityGroupRule);
 
+
+    /**
+     * See {@link NetQuota#getRbacPolicy()} for details
+     *
+     * @param rbacPolicy
+     * @return NetQuotaBuilder
+     */
+    NetQuotaBuilder rbacPolicy(Integer rbacPolicy);
+
+    /**
+     * See {@link NetQuota#getSubnetPool()} for details
+     *
+     * @param subnetPool
+     * @return NetQuotaBuilder
+     */
+    NetQuotaBuilder subnetpool(Integer subnetpool);
 }

--- a/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronNetQuota.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronNetQuota.java
@@ -35,6 +35,10 @@ public class NeutronNetQuota implements NetQuota {
     private int securityGroup;
     @JsonProperty("security_group_rule")
     private int securityGroupRule;
+    @JsonProperty("subnetpool")
+    private int subnetpool;
+    @JsonProperty("rbac_policy")
+    private int rbacPolicy;
 
     public static NetQuotaBuilder builder() {
         return new NetQuotaConcreteBuilder();
@@ -77,6 +81,16 @@ public class NeutronNetQuota implements NetQuota {
     }
 
     @Override
+    public int getSubnetpool() {
+        return subnetpool;
+    }
+
+    @Override
+    public int getRbacPolicy() {
+        return rbacPolicy;
+    }
+
+    @Override
     public int getSecurityGroupRule() {
         return securityGroupRule;
     }
@@ -85,8 +99,8 @@ public class NeutronNetQuota implements NetQuota {
     public String toString() {
         return toStringHelper(this)
                 .add("subnet", subnet).add("router", router).add("port", port)
-                .add("network", network).add("floatingIp", floatingIp)
-                .toString();
+                .add("network", network).add("floatingIp", floatingIp).add("subnetpool", subnetpool)
+                .add("rbacPolicy", rbacPolicy).toString();
     }
 
     public static class NetQuotaConcreteBuilder implements NetQuotaBuilder {
@@ -151,6 +165,18 @@ public class NeutronNetQuota implements NetQuota {
         @Override
         public NetQuotaBuilder securityGroupRule(int securityGroupRule) {
             model.securityGroupRule = securityGroupRule;
+            return this;
+        }
+
+        @Override
+        public NetQuotaBuilder subnetpool(Integer subnetpool) {
+            model.subnetpool = subnetpool;
+            return this;
+        }
+
+        @Override
+        public NetQuotaBuilder rbacPolicy(Integer rbacPolicy) {
+            model.rbacPolicy = rbacPolicy;
             return this;
         }
     }

--- a/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronNetQuota.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronNetQuota.java
@@ -169,13 +169,13 @@ public class NeutronNetQuota implements NetQuota {
         }
 
         @Override
-        public NetQuotaBuilder subnetpool(Integer subnetpool) {
+        public NetQuotaBuilder subnetpool(int subnetpool) {
             model.subnetpool = subnetpool;
             return this;
         }
 
         @Override
-        public NetQuotaBuilder rbacPolicy(Integer rbacPolicy) {
+        public NetQuotaBuilder rbacPolicy(int rbacPolicy) {
             model.rbacPolicy = rbacPolicy;
             return this;
         }


### PR DESCRIPTION
# PR description

Neutron: Add subnetpool and RBAC policy count to network quota.
API Doc:
* Get all: https://docs.openstack.org/api-ref/network/v2/?expanded=#list-quotas-for-projects-with-non-default-quota-values
* Update: https://docs.openstack.org/api-ref/network/v2/?expanded=#update-quota-for-a-project

## Submitter checklist

Make sure that following is addressed to make the PR easier to process:

- [x] If applicable, changes are covered by either a unit or a functional test.
- [x] If applicable, changes ware verified manually against an OpenStack instance.
- [x] If the change is API related, the PR description links to OpenStack API documentation of that particular endpoint/request (https://docs.openstack.org/api-quick-start/#current-api-versions).
- [x] If the change concerns particular OpenStack service, its name is used as a PR name prefix (ex.: "Neutron: Add floatingIp port forwardings service").
- [ ] If the PR closes existing GitHub issue, PR name have prefix: `Fix #NNN: `.
