### PR TITLE
Nova: Support rebuild additional parameters

### DIFF
--- a/core-test/src/main/java/org/openstack4j/api/compute/ServerTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/compute/ServerTests.java
@@ -1,15 +1,10 @@
 package org.openstack4j.api.compute;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import okhttp3.mockwebserver.RecordedRequest;
 import org.openstack4j.api.AbstractTest;
 import org.openstack4j.api.Builders;
 import org.openstack4j.api.exceptions.ServerResponseException;
@@ -22,7 +17,11 @@ import org.openstack4j.model.compute.actions.RebuildOptions;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import okhttp3.mockwebserver.RecordedRequest;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 /**
  * Test cases for Server based Services

--- a/core-test/src/main/java/org/openstack4j/api/compute/ServerTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/compute/ServerTests.java
@@ -1,25 +1,28 @@
 package org.openstack4j.api.compute;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import okhttp3.mockwebserver.RecordedRequest;
-import org.openstack4j.api.AbstractTest;
-import org.openstack4j.api.Builders;
-import org.openstack4j.api.exceptions.ServerResponseException;
-import org.openstack4j.model.compute.Server;
-import org.openstack4j.model.compute.Server.Status;
-import org.openstack4j.model.compute.ServerPassword;
-import org.openstack4j.model.compute.actions.EvacuateOptions;
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.openstack4j.api.AbstractTest;
+import org.openstack4j.api.Builders;
+import org.openstack4j.api.exceptions.ServerResponseException;
+import org.openstack4j.model.common.ActionResponse;
+import org.openstack4j.model.compute.Server;
+import org.openstack4j.model.compute.Server.Status;
+import org.openstack4j.model.compute.ServerPassword;
+import org.openstack4j.model.compute.actions.EvacuateOptions;
+import org.openstack4j.model.compute.actions.RebuildOptions;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import okhttp3.mockwebserver.RecordedRequest;
 
 /**
  * Test cases for Server based Services
@@ -33,6 +36,7 @@ public class ServerTests extends AbstractTest {
     private static final String JSON_SERVER_CREATE = "/compute/server_create.json";
     private static final String JSON_SERVER_EVACUATE = "/compute/server_evacuate.json";
     private static final String JSON_SERVER_CONSOLE_OUTPUT = "/compute/server_console_output.json";
+    private static final String JSON_SERVER_REBUILD = "/compute/server_rebuild.json";
 
     @Test
     public void listServer() throws Exception {
@@ -153,6 +157,19 @@ public class ServerTests extends AbstractTest {
 
         String console = osv3().compute().servers().getConsoleOutput("non-existing-uuid", 0);
         assertNull(console);
+
+        takeRequest();
+    }
+
+    @Test
+    public void rebuildServer() throws Exception {
+        respondWith(JSON_SERVER_REBUILD);
+
+        RebuildOptions rebuildOptions = RebuildOptions.create().image("70a599e0-31e7-49b7-b260-868f441e862b").userData("ZWNobyAiaGVsbG8gd29ybGQi");
+        
+        ActionResponse actionResponse = osv3().compute().servers().rebuild("0c37a84a-c757-4f22-8c7f-0bf8b6970886", rebuildOptions);
+        assertNotNull(actionResponse);
+        assertTrue(actionResponse.isSuccess());
 
         takeRequest();
     }

--- a/core-test/src/main/resources/compute/server_rebuild.json
+++ b/core-test/src/main/resources/compute/server_rebuild.json
@@ -1,0 +1,89 @@
+{
+    "server": {
+        "OS-DCF:diskConfig": "AUTO",
+        "OS-EXT-AZ:availability_zone": "us-west",
+        "OS-EXT-SRV-ATTR:host": "compute",
+        "OS-EXT-SRV-ATTR:hostname": "new-server-test",
+        "OS-EXT-SRV-ATTR:hypervisor_hostname": "fake-mini",
+        "OS-EXT-SRV-ATTR:instance_name": "instance-00000001",
+        "OS-EXT-SRV-ATTR:kernel_id": "",
+        "OS-EXT-SRV-ATTR:launch_index": 0,
+        "OS-EXT-SRV-ATTR:ramdisk_id": "",
+        "OS-EXT-SRV-ATTR:reservation_id": "r-t61j9da6",
+        "OS-EXT-SRV-ATTR:root_device_name": "/dev/sda",
+        "OS-EXT-STS:power_state": 1,
+        "OS-EXT-STS:task_state": null,
+        "OS-EXT-STS:vm_state": "active",
+        "OS-SRV-USG:launched_at": "2019-04-23T15:19:10.855016",
+        "OS-SRV-USG:terminated_at": null,
+        "accessIPv4": "1.2.3.4",
+        "accessIPv6": "80fe::",
+        "addresses": {
+            "private": [
+                {
+                    "OS-EXT-IPS-MAC:mac_addr": "00:0c:29:0d:11:74",
+                    "OS-EXT-IPS:type": "fixed",
+                    "addr": "192.168.1.30",
+                    "version": 4
+                }
+            ]
+        },
+        "adminPass": "seekr3t",
+        "config_drive": "",
+        "created": "2019-04-23T17:10:22Z",
+        "description": null,
+        "flavor": {
+            "disk": 1,
+            "ephemeral": 0,
+            "extra_specs": {},
+            "original_name": "m1.tiny",
+            "ram": 512,
+            "swap": 0,
+            "vcpus": 1
+        },
+        "hostId": "2091634baaccdc4c5a1d57069c833e402921df696b7f970791b12ec6",
+        "host_status": "UP",
+        "id": "0c37a84a-c757-4f22-8c7f-0bf8b6970886",
+        "image": {
+            "id": "70a599e0-31e7-49b7-b260-868f441e862b",
+            "links": [
+                {
+                    "href": "http://openstack.example.com/6f70656e737461636b20342065766572/images/70a599e0-31e7-49b7-b260-868f441e862b",
+                    "rel": "bookmark"
+                }
+            ]
+        },
+        "key_name": null,
+        "links": [
+            {
+                "href": "http://openstack.example.com/v2.1/6f70656e737461636b20342065766572/servers/0c37a84a-c757-4f22-8c7f-0bf8b6970886",
+                "rel": "self"
+            },
+            {
+                "href": "http://openstack.example.com/6f70656e737461636b20342065766572/servers/0c37a84a-c757-4f22-8c7f-0bf8b6970886",
+                "rel": "bookmark"
+            }
+        ],
+        "locked": false,
+        "locked_reason": null,
+        "metadata": {
+            "meta_var": "meta_val"
+        },
+        "name": "foobar",
+        "os-extended-volumes:volumes_attached": [],
+        "progress": 0,
+        "security_groups": [
+            {
+                "name": "default"
+            }
+        ],
+        "server_groups": [],
+        "status": "ACTIVE",
+        "tags": [],
+        "tenant_id": "6f70656e737461636b20342065766572",
+        "trusted_image_certificates": null,
+        "updated": "2019-04-23T17:10:24Z",
+        "user_data": "ZWNobyAiaGVsbG8gd29ybGQi",
+        "user_id": "admin"
+    }
+}

--- a/core/src/main/java/org/openstack4j/model/compute/actions/RebuildOptions.java
+++ b/core/src/main/java/org/openstack4j/model/compute/actions/RebuildOptions.java
@@ -51,11 +51,11 @@ public final class RebuildOptions extends BaseActionOptions {
         return this;
     }
     
-    public void addPersonality(List<Personality> personality) {
+    public void personality(List<Personality> personality) {
         add(Option.PERSONALITY, personality);
     }
     
-    public void setMetadata(Map<String, String> metadata) {
+    public void metadata(Map<String, String> metadata) {
         add(Option.METADATA, metadata);
     }
 

--- a/core/src/main/java/org/openstack4j/model/compute/actions/RebuildOptions.java
+++ b/core/src/main/java/org/openstack4j/model/compute/actions/RebuildOptions.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import org.openstack4j.model.compute.Personality;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.Lists;
 
 /**
  * Options used to invoke the Rebuild Action on a Server
@@ -14,8 +13,6 @@ import com.google.common.collect.Lists;
  * @author Jeremy Unruh
  */
 public final class RebuildOptions extends BaseActionOptions {
-	private List<Personality> personality;
-    
     private RebuildOptions() {
         super();
     }
@@ -54,12 +51,8 @@ public final class RebuildOptions extends BaseActionOptions {
         return this;
     }
     
-    public void addPersonality(String path, String contents) {
-        if (personality == null) {
-            personality = Lists.newArrayList();
-            add(Option.PERSONALITY, personality);
-        }
-        personality.add(new Personality(path, contents));
+    public void addPersonality(List<Personality> personality) {
+        add(Option.PERSONALITY, personality);
     }
     
     public void setMetadata(Map<String, String> metadata) {

--- a/core/src/main/java/org/openstack4j/model/compute/actions/RebuildOptions.java
+++ b/core/src/main/java/org/openstack4j/model/compute/actions/RebuildOptions.java
@@ -103,7 +103,7 @@ public final class RebuildOptions extends BaseActionOptions {
     }
     
     private enum Option implements OptionEnum {
-    	IMAGE("imageRef"),
+        IMAGE("imageRef"),
         NAME("name"),
         ADMIN_PASS("adminPass"),
         USER_DATA("user_data"),

--- a/core/src/main/java/org/openstack4j/model/compute/actions/RebuildOptions.java
+++ b/core/src/main/java/org/openstack4j/model/compute/actions/RebuildOptions.java
@@ -1,5 +1,12 @@
 package org.openstack4j.model.compute.actions;
 
+import java.util.List;
+import java.util.Map;
+
+import org.openstack4j.model.compute.Personality;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.Lists;
 
 /**
  * Options used to invoke the Rebuild Action on a Server
@@ -7,7 +14,8 @@ package org.openstack4j.model.compute.actions;
  * @author Jeremy Unruh
  */
 public final class RebuildOptions extends BaseActionOptions {
-
+	private List<Personality> personality;
+    
     private RebuildOptions() {
         super();
     }
@@ -40,6 +48,23 @@ public final class RebuildOptions extends BaseActionOptions {
         add(Option.NAME, name);
         return this;
     }
+    
+    public RebuildOptions userData(String userData) {
+        add(Option.USER_DATA, userData);
+        return this;
+    }
+    
+    public void addPersonality(String path, String contents) {
+        if (personality == null) {
+            personality = Lists.newArrayList();
+            add(Option.PERSONALITY, personality);
+        }
+        personality.add(new Personality(path, contents));
+    }
+    
+    public void setMetadata(Map<String, String> metadata) {
+        add(Option.METADATA, metadata);
+    }
 
     /**
      * Can optionally specify a new admin password to be used during the rebuild
@@ -63,11 +88,28 @@ public final class RebuildOptions extends BaseActionOptions {
     public String getImageRef() {
         return get(Option.IMAGE);
     }
+    
+    @JsonProperty("user_data")
+    public String getUserData() {
+        return get(Option.USER_DATA);
+    }
+    
+    public List<Personality> getPersonality() {
+        return get(Option.PERSONALITY);
+    }
 
+    public Map<String, String> getMetadata() {
+        return get(Option.METADATA);
+    }
+    
     private enum Option implements OptionEnum {
-        IMAGE("imageRef"),
+    	IMAGE("imageRef"),
         NAME("name"),
-        ADMIN_PASS("adminPass");
+        ADMIN_PASS("adminPass"),
+        USER_DATA("user_data"),
+        PERSONALITY("personality"),
+        METADATA("metadata");
+    	
         private final String param;
 
         private Option(String param) {

--- a/core/src/main/java/org/openstack4j/model/compute/actions/RebuildOptions.java
+++ b/core/src/main/java/org/openstack4j/model/compute/actions/RebuildOptions.java
@@ -51,12 +51,14 @@ public final class RebuildOptions extends BaseActionOptions {
         return this;
     }
     
-    public void personality(List<Personality> personality) {
+    public RebuildOptions personality(List<Personality> personality) {
         add(Option.PERSONALITY, personality);
+        return this;
     }
     
-    public void metadata(Map<String, String> metadata) {
+    public RebuildOptions metadata(Map<String, String> metadata) {
         add(Option.METADATA, metadata);
+        return this;
     }
 
     /**

--- a/core/src/main/java/org/openstack4j/openstack/compute/domain/actions/RebuildAction.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/domain/actions/RebuildAction.java
@@ -4,10 +4,10 @@ import java.util.List;
 import java.util.Map;
 
 import org.openstack4j.model.compute.Personality;
-import org.openstack4j.model.compute.actions.RebuildOptions;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
+import org.openstack4j.model.compute.actions.RebuildOptions;
 
 /**
  * An Action which Rebuilds an existing Server Instance

--- a/core/src/main/java/org/openstack4j/openstack/compute/domain/actions/RebuildAction.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/domain/actions/RebuildAction.java
@@ -1,8 +1,13 @@
 package org.openstack4j.openstack.compute.domain.actions;
 
+import java.util.List;
+import java.util.Map;
+
+import org.openstack4j.model.compute.Personality;
+import org.openstack4j.model.compute.actions.RebuildOptions;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
-import org.openstack4j.model.compute.actions.RebuildOptions;
 
 /**
  * An Action which Rebuilds an existing Server Instance
@@ -23,6 +28,11 @@ public class RebuildAction implements ServerAction {
     @JsonProperty
     private String adminPass;
 
+    @JsonProperty("user_data")
+    private String userData;
+    private List<Personality> personality;
+    private Map<String, String> metadata;
+    
     public static RebuildAction create(RebuildOptions options) {
         RebuildAction action = new RebuildAction();
 
@@ -30,6 +40,9 @@ public class RebuildAction implements ServerAction {
             action.name = options.getName();
             action.adminPass = options.getAdminPass();
             action.imageRef = options.getImageRef();
+            action.userData = options.getUserData();
+            action.personality = options.getPersonality();
+            action.metadata = options.getMetadata();
         }
         return action;
     }
@@ -45,5 +58,15 @@ public class RebuildAction implements ServerAction {
     public String getAdminPass() {
         return adminPass;
     }
-
+    public String getUserData() {
+        return userData;
+    }
+    
+    public List<Personality> getPersonality() {
+        return personality;
+    }
+    
+    public Map<String, String> getMetadata() {
+        return metadata;
+    }
 }


### PR DESCRIPTION
# PR description

Add user data, personality, metadata to server rebuilding parameters.
API doc: https://docs.openstack.org/api-ref/compute/?expanded=rebuild-server-rebuild-action-detail#rebuild-server-rebuild-action

## Submitter checklist

Make sure that following is addressed to make the PR easier to process:

- [x] If applicable, changes are covered by either a unit or a functional test.
- [x] If applicable, changes ware verified manually against an OpenStack instance.
- [x] If the change is API related, the PR description links to OpenStack API documentation of that particular endpoint/request (https://docs.openstack.org/api-quick-start/#current-api-versions).
- [x] If the change concerns particular OpenStack service, its name is used as a PR name prefix (ex.: "Neutron: Add floatingIp port forwardings service").
- [x] If the PR closes existing GitHub issue, PR name have prefix: `Fix #NNN: `.
