### PR TITLE
Neutron: Add port security enabled to network creation

### DIFF
--- a/core-test/src/main/java/org/openstack4j/api/network/NetworkTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/network/NetworkTests.java
@@ -56,10 +56,11 @@ public class NetworkTests extends AbstractTest {
     public void createNetwork() throws Exception {
         respondWith(JSON_NETWORK_EXTERNAL);
         Network n = osv3().networking().network()
-                .create(Builders.network().name(NETWORK_NAME).isRouterExternal(true).adminStateUp(true).build());
+                .create(Builders.network().name(NETWORK_NAME).isRouterExternal(true).adminStateUp(true).isPortSecurityEnabled(true).build());
         server.takeRequest();
         assertEquals(n.getName(), NETWORK_NAME);
         assertEquals(n.getStatus(), State.ACTIVE);
+        assertTrue(n.isPortSecurityEnabled());
         assertTrue(n.isRouterExternal());
     }
 

--- a/core/src/main/java/org/openstack4j/model/network/Network.java
+++ b/core/src/main/java/org/openstack4j/model/network/Network.java
@@ -74,5 +74,8 @@ public interface Network extends Resource, TimeEntity, Buildable<NetworkBuilder>
      */
     List<String> getAvailabilityZones();
 
-
+    /**
+     * @return true if the port security enabled is shared
+     */
+    Boolean isPortSecurityEnabled();
 }

--- a/core/src/main/java/org/openstack4j/model/network/builder/NetworkBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/network/builder/NetworkBuilder.java
@@ -55,4 +55,9 @@ public interface NetworkBuilder extends Builder<NetworkBuilder, Network> {
      * @see Network#getAvailabilityZoneHints()
      */
     NetworkBuilder addAvailabilityZoneHints(String availabilityZone);
+    
+    /**
+     * @see Network#isPortSecurityEnabled()
+     */
+    NetworkBuilder isPortSecurityEnabled(Boolean portSecurityEnabled);
 }

--- a/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronNetwork.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronNetwork.java
@@ -50,6 +50,8 @@ public class NeutronNetwork implements Network {
     private List<String> availabilityZoneHints;
     @JsonProperty("availability_zones")
     private List<String> availabilityZones;
+    @JsonProperty("port_security_enabled")
+    private Boolean portSecurityEnabled;
     @JsonProperty("created_at")
     private Date createdTime;
     @JsonProperty("updated_at")
@@ -225,7 +227,15 @@ public class NeutronNetwork implements Network {
     public List<String> getAvailabilityZones() {
         return availabilityZones;
     }
-
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Boolean isPortSecurityEnabled() {
+        return portSecurityEnabled;
+    }
+    
     /**
      * {@inheritDoc}
      */
@@ -252,6 +262,7 @@ public class NeutronNetwork implements Network {
                 .add("adminStateUp", adminStateUp).add("tenantId", tenantId).add("provider:network_type", networkType).add("router:external", routerExternal)
                 .add("id", id).add("shared", shared).add("provider:segmentation_id", providerSegID)
                 .add("mtu", mtu).add("availabilityZoneHints", availabilityZoneHints).add("availabilityZones", availabilityZones)
+                .add("portSecurityEnabled", portSecurityEnabled)
                 .add("created_at", createdTime).add("updated_at", updatedTime)
                 .toString();
     }
@@ -263,7 +274,7 @@ public class NeutronNetwork implements Network {
     public int hashCode() {
         return java.util.Objects.hash(name, status, subnets,
                 providerPhyNet, adminStateUp, tenantId, networkType,
-                routerExternal, id, shared, providerSegID, availabilityZoneHints, availabilityZones,
+                routerExternal, id, shared, providerSegID, availabilityZoneHints, availabilityZones, portSecurityEnabled,
                 createdTime, updatedTime);
     }
 
@@ -291,6 +302,7 @@ public class NeutronNetwork implements Network {
                     java.util.Objects.equals(providerSegID, that.providerSegID) &&
                     java.util.Objects.equals(availabilityZoneHints, that.availabilityZoneHints) &&
                     java.util.Objects.equals(availabilityZones, that.availabilityZones) &&
+                    java.util.Objects.equals(portSecurityEnabled, that.portSecurityEnabled) &&
                     java.util.Objects.equals(createdTime, that.createdTime) &&
                     java.util.Objects.equals(updatedTime, that.updatedTime)) {
                 return true;
@@ -388,6 +400,12 @@ public class NeutronNetwork implements Network {
                 m.availabilityZoneHints = new ArrayList<>();
             }
             m.availabilityZoneHints.add(availabilityZone);
+            return this;
+        }
+        
+        @Override
+        public NetworkBuilder isPortSecurityEnabled(Boolean portSecurityEnabled) {
+            m.portSecurityEnabled = portSecurityEnabled;
             return this;
         }
     }


### PR DESCRIPTION
# PR description

Add the port security enabled parameter to network creation.
API doc: https://docs.openstack.org/api-ref/network/v2/?expanded=create-port-detail,create-network-detail#create-network

## Submitter checklist

Make sure that following is addressed to make the PR easier to process:

- [x] If applicable, changes are covered by either a unit or a functional test.
- [x] If applicable, changes ware verified manually against an OpenStack instance.
- [x] If the change is API related, the PR description links to OpenStack API documentation of that particular endpoint/request (https://docs.openstack.org/api-quick-start/#current-api-versions).
- [x] If the change concerns particular OpenStack service, its name is used as a PR name prefix (ex.: "Neutron: Add floatingIp port forwardings service").
- [x] If the PR closes existing GitHub issue, PR name have prefix: `Fix #NNN: `.
