### PR TITLE
Nova: Add statuses and a filter to list migrations

### DIFF
--- a/core-test/src/main/java/org/openstack4j/api/compute/MigrationTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/compute/MigrationTests.java
@@ -25,6 +25,7 @@ public class MigrationTests extends AbstractTest {
 
         assertEquals(2, migrations.size());
         assertEquals(Status.DONE, migrations.get(0).getStatus());
+        assertEquals(Status.CONFIRMED, migrations.get(1).getStatus());
     }
 
     @Override

--- a/core-test/src/main/resources/compute/migrations.json
+++ b/core-test/src/main/resources/compute/migrations.json
@@ -25,7 +25,7 @@
             "old_instance_type_id": 5,
             "source_compute": "compute10",
             "source_node": "node10",
-            "status": "Done",
+            "status": "Confirmed",
             "updated_at": "2013-10-22T13:42:02.000000"
         }
     ]

--- a/core/src/main/java/org/openstack4j/model/compute/ext/Migration.java
+++ b/core/src/main/java/org/openstack4j/model/compute/ext/Migration.java
@@ -75,7 +75,9 @@ public interface Migration extends ModelEntity {
     public enum Status {
         MIGRATING,
         ERROR,
-        DONE;
+        DONE,
+        FINISHED, 
+        CONFIRMED;
 
         @JsonCreator
         public static Status forValue(String value) {

--- a/core/src/main/java/org/openstack4j/model/compute/ext/MigrationsFilter.java
+++ b/core/src/main/java/org/openstack4j/model/compute/ext/MigrationsFilter.java
@@ -49,5 +49,16 @@ public class MigrationsFilter extends BaseFilter {
         filter("cell_name", cellName);
         return this;
     }
-
+    
+    /**
+     * Filters the instance UUID.
+     * 
+     * @param instanceUuid
+     *            Instance UUID
+     * @return MigrationsFilter
+     */
+    public MigrationsFilter instanceUuid(String instanceUuid) {
+        filter("instance_uuid", instanceUuid);
+        return this;
+    }
 }


### PR DESCRIPTION
# PR description

Add FINISHED, CONFIRMED statuses and an instance UUID filter to the list migrations.
API doc: https://docs.openstack.org/api-ref/compute/?expanded=list-migrations-detail,id312-detail#list-migrations

## Submitter checklist

Make sure that following is addressed to make the PR easier to process:

- [x] If applicable, changes are covered by either a unit or a functional test.
- [x] If applicable, changes ware verified manually against an OpenStack instance.
- [x] If the change is API related, the PR description links to OpenStack API documentation of that particular endpoint/request (https://docs.openstack.org/api-quick-start/#current-api-versions).
- [x] If the change concerns particular OpenStack service, its name is used as a PR name prefix (ex.: "Neutron: Add floatingIp port forwardings service").
- [x] If the PR closes existing GitHub issue, PR name have prefix: `Fix #NNN: `.
