### PR TITLE
Glance: Add image uploading listener

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -190,6 +190,12 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
+        
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>4.4.12</version>
+        </dependency>
     </dependencies>
     <reporting>
         <plugins>

--- a/core/src/main/java/org/openstack4j/api/image/v2/ImageService.java
+++ b/core/src/main/java/org/openstack4j/api/image/v2/ImageService.java
@@ -12,6 +12,7 @@ import org.openstack4j.model.image.v2.CachedImage;
 import org.openstack4j.model.image.v2.Image;
 import org.openstack4j.model.image.v2.ImageUpdate;
 import org.openstack4j.model.image.v2.Member;
+import org.openstack4j.openstack.common.FileUploadProgressListener;
 
 /**
  * OpenStack (Glance) Image V2 support
@@ -154,6 +155,9 @@ public interface ImageService extends RestService {
      * Uploads binary image data
      */
     ActionResponse upload(String imageId, Payload<?> payload, @Nullable Image image);
+    
+    ActionResponse upload(String imageId, Payload<?> payload, @Nullable Image image, int bufferSize,
+            FileUploadProgressListener listener);
 
     /**
      * Downloads binary image data

--- a/core/src/main/java/org/openstack4j/core/transport/HttpRequest.java
+++ b/core/src/main/java/org/openstack4j/core/transport/HttpRequest.java
@@ -15,6 +15,7 @@ import org.openstack4j.api.types.ServiceType;
 import org.openstack4j.core.transport.functions.EndpointURIFromRequestFunction;
 import org.openstack4j.model.ModelEntity;
 import org.openstack4j.model.common.Payload;
+import org.openstack4j.openstack.common.FileUploadProgressListener;
 
 /**
  * A Request Delegate which aids in building the request that is compatible with the OpenStack Rest API. The request is used to encoding as well as keeping reference to
@@ -34,6 +35,8 @@ public class HttpRequest<R> {
     String contentType = ClientConstants.CONTENT_TYPE_JSON;
     HttpMethod method = HttpMethod.GET;
     String json;
+    private FileUploadProgressListener fileUploadProgressListener;
+    private int bufferSize;
     private Config config;
     private Map<String, List<Object>> queryParams;
     private Function<String, String> endpointFunc;
@@ -175,7 +178,23 @@ public class HttpRequest<R> {
     public Config getConfig() {
         return config != null ? config: Config.DEFAULT;
     }
+    
+    public void setFileUploadProgressListener(FileUploadProgressListener fileUploadProgressListener) {
+        this.fileUploadProgressListener = fileUploadProgressListener;
+    }
 
+    public FileUploadProgressListener getFileUploadProgressListener() {
+        return this.fileUploadProgressListener;
+    }
+
+    public void setBufferSize(int bufferSize) {
+        this.bufferSize = bufferSize;
+    }
+    
+    public int getBufferSize() {
+        return this.bufferSize;
+    }
+    
     /**
      * Append query parameters into the url.
      */
@@ -341,6 +360,16 @@ public class HttpRequest<R> {
          */
         public RequestBuilder<R> header(String name, Object value) {
             request.getHeaders().put(name, value);
+            return this;
+        }
+
+        public RequestBuilder<R> fileUploadProgressListener(FileUploadProgressListener fileUploadProgressListener) {
+            request.setFileUploadProgressListener(fileUploadProgressListener);
+            return this;
+        }
+
+        public RequestBuilder<R> bufferSize(int bufferSize) {
+            request.setBufferSize(bufferSize);
             return this;
         }
 

--- a/core/src/main/java/org/openstack4j/openstack/common/FileEntity.java
+++ b/core/src/main/java/org/openstack4j/openstack/common/FileEntity.java
@@ -1,0 +1,119 @@
+package org.openstack4j.openstack.common;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.apache.http.entity.AbstractHttpEntity;
+
+/**
+ * TODO add description.
+ *
+ * <p>
+ * Class responsibility:
+ * </p>
+ */
+
+public class FileEntity extends AbstractHttpEntity implements Cloneable
+{
+    protected InputStream is;
+    private FileUploadProgressListener listener;
+    private long transferredByte;
+    private int bufferSize;
+
+    private final long SLEEP_TIME = 3;
+
+    public FileEntity(InputStream is, String contentType, int bufferSize, FileUploadProgressListener listener)
+    {
+        super();
+        if (is == null)
+        {
+            throw new IllegalArgumentException("File may not be null");
+        }
+        this.is = is;
+        this.transferredByte = 0;
+        this.listener = listener;
+
+        if (bufferSize <= 0)
+        {
+            // 1MB
+            bufferSize = 1048576;
+        } else
+        {
+            this.bufferSize = bufferSize;
+        }
+
+        setContentType(contentType);
+    }
+
+    public boolean isRepeatable()
+    {
+        return true;
+    }
+
+    public long getContentLength()
+    {
+        if (listener != null)
+        {
+            return listener.getFileSize();
+        }
+
+        try
+        {
+            if (is instanceof FileInputStream)
+            {
+                return ((FileInputStream) is).getChannel().size();
+            }
+        } catch (IOException e)
+        {
+            return 0;
+        }
+        return 0;
+    }
+
+    public InputStream getContent() throws IOException
+    {
+        return is;
+    }
+
+    public void writeTo(final OutputStream outstream) throws IOException
+    {
+        if (outstream == null)
+        {
+            throw new IllegalArgumentException("Output stream may not be null");
+        }
+
+        try
+        {
+            byte[] buffer = new byte[bufferSize];
+            int w;
+            while ((w = is.read(buffer)) != -1)
+            {
+                outstream.write(buffer, 0, w);
+                this.transferredByte += w;
+                listener.updateTransferedByte(transferredByte);
+                Thread.sleep(SLEEP_TIME);
+            }
+            outstream.flush();
+        } catch (InterruptedException e)
+        {
+            throw new RuntimeException(e.getMessage());
+            // throw e;
+        } finally
+        {
+            is.close();
+        }
+    }
+
+    public boolean isStreaming()
+    {
+        return false;
+    }
+
+    @Override
+    public Object clone() throws CloneNotSupportedException
+    {
+        return super.clone();
+    }
+}

--- a/core/src/main/java/org/openstack4j/openstack/common/FileUploadProgressListener.java
+++ b/core/src/main/java/org/openstack4j/openstack/common/FileUploadProgressListener.java
@@ -1,0 +1,8 @@
+package org.openstack4j.openstack.common;
+
+public interface FileUploadProgressListener
+{
+    void updateTransferedByte(long transferedByte);
+
+    long getFileSize();
+}

--- a/core/src/main/java/org/openstack4j/openstack/image/v2/internal/ImageServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/image/v2/internal/ImageServiceImpl.java
@@ -22,6 +22,7 @@ import org.openstack4j.model.image.v2.CachedImage;
 import org.openstack4j.model.image.v2.Image;
 import org.openstack4j.model.image.v2.ImageUpdate;
 import org.openstack4j.model.image.v2.Member;
+import org.openstack4j.openstack.common.FileUploadProgressListener;
 import org.openstack4j.openstack.image.v2.domain.CachedGlanceImage.CachedImages;
 import org.openstack4j.openstack.image.v2.domain.GlanceImage;
 import org.openstack4j.openstack.image.v2.domain.GlanceImageUpdate;
@@ -160,6 +161,20 @@ public class ImageServiceImpl extends BaseImageServices implements ImageService 
         checkNotNull(imageId);
         checkNotNull(payload);
         return put(ActionResponse.class, uri("/images/%s/file", imageId)).header(HEADER_CONTENT_TYPE, CONTENT_TYPE_OCTECT_STREAM).entity(payload).execute();
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ActionResponse upload(String imageId, Payload<?> payload, @Nullable Image image, int bufferSize,
+        FileUploadProgressListener listener)
+    {
+        checkNotNull(imageId);
+        checkNotNull(payload);
+        return put(ActionResponse.class, uri("/images/%s/file", imageId))
+            .header(HEADER_CONTENT_TYPE, CONTENT_TYPE_OCTECT_STREAM).entity(payload)
+            .fileUploadProgressListener(listener).bufferSize(bufferSize).execute();
     }
 
     /**

--- a/core/src/main/java/org/openstack4j/openstack/internal/BaseOpenStackService.java
+++ b/core/src/main/java/org/openstack4j/openstack/internal/BaseOpenStackService.java
@@ -16,6 +16,7 @@ import org.openstack4j.model.common.Payload;
 import org.openstack4j.model.identity.AuthVersion;
 import org.openstack4j.model.identity.v2.Access;
 import org.openstack4j.model.identity.v3.Service;
+import org.openstack4j.openstack.common.FileUploadProgressListener;
 
 import static org.openstack4j.core.transport.ClientConstants.HEADER_USER_AGENT;
 import static org.openstack4j.core.transport.ClientConstants.USER_AGENT;
@@ -229,6 +230,18 @@ public class BaseOpenStackService {
             return this;
         }
 
+        public Invocation<R> fileUploadProgressListener(FileUploadProgressListener fileUploadProgressListener)
+        {
+            req.fileUploadProgressListener(fileUploadProgressListener);
+            return this;
+        }
+
+        public Invocation<R> bufferSize(int bufferSize)
+        {
+            req.bufferSize(bufferSize);
+            return this;
+        }
+        
         public Invocation<R> header(String name, Object value) {
             req.header(name, value);
             return this;


### PR DESCRIPTION
# PR description

Add image uploading listener.
It can show progress of uploading in an application.
API: https://docs.openstack.org/api-ref/image/v2/?expanded=upload-binary-image-data-detail#upload-binary-image-data

## Submitter checklist

Make sure that following is addressed to make the PR easier to process:

- [x] If applicable, changes are covered by either a unit or a functional test.
- [x] If applicable, changes ware verified manually against an OpenStack instance.
- [x] If the change is API related, the PR description links to OpenStack API documentation of that particular endpoint/request (https://docs.openstack.org/api-quick-start/#current-api-versions).
- [x] If the change concerns particular OpenStack service, its name is used as a PR name prefix (ex.: "Neutron: Add floatingIp port forwardings service").
- [x] If the PR closes existing GitHub issue, PR name have prefix: `Fix #NNN: `.
