### PR TITLE
Object Storage: Added option to specify headers for copy operations

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -17,7 +17,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>1.3.3</version>
+                <version>3.2.3</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/core/src/main/java/org/openstack4j/api/storage/ObjectStorageObjectService.java
+++ b/core/src/main/java/org/openstack4j/api/storage/ObjectStorageObjectService.java
@@ -9,10 +9,7 @@ import org.openstack4j.model.common.DLPayload;
 import org.openstack4j.model.common.Payload;
 import org.openstack4j.model.storage.block.options.DownloadOptions;
 import org.openstack4j.model.storage.object.SwiftObject;
-import org.openstack4j.model.storage.object.options.ObjectDeleteOptions;
-import org.openstack4j.model.storage.object.options.ObjectListOptions;
-import org.openstack4j.model.storage.object.options.ObjectLocation;
-import org.openstack4j.model.storage.object.options.ObjectPutOptions;
+import org.openstack4j.model.storage.object.options.*;
 
 /**
  * A service responsible for maintaining directory and file objects within containers for
@@ -139,6 +136,16 @@ public interface ObjectStorageObjectService extends RestService {
      * @return the ETAG checksum if successful
      */
     String copy(ObjectLocation source, ObjectLocation dest);
+
+    /**
+     * Copies an object to another object in the object store
+     *
+     * @param source the source container and object name
+     * @param dest the destination container and object name
+     * @param options the copy options
+     * @return the ETAG checksum if successful
+     */
+    String copy(ObjectLocation source, ObjectLocation dest, ObjectCopyOptions options);
 
     /**
      * Gets the metadata for the specified object location

--- a/core/src/main/java/org/openstack4j/model/storage/object/options/ObjectCopyOptions.java
+++ b/core/src/main/java/org/openstack4j/model/storage/object/options/ObjectCopyOptions.java
@@ -4,7 +4,9 @@ import com.google.common.collect.Maps;
 import org.openstack4j.openstack.storage.object.functions.MetadataToHeadersFunction;
 
 import javax.annotation.Nullable;
+import java.util.Date;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.openstack4j.model.storage.object.SwiftHeaders.CONTENT_TYPE;
 import static org.openstack4j.model.storage.object.SwiftHeaders.OBJECT_METADATA_PREFIX;
@@ -15,6 +17,8 @@ import static org.openstack4j.model.storage.object.SwiftHeaders.OBJECT_METADATA_
  * @author Lukas Alt
  */
 public class ObjectCopyOptions {
+
+    public static final ObjectCopyOptions NONE = new ObjectCopyOptions();
     private final Map<String, String> headers = Maps.newHashMap();
 
     private ObjectCopyOptions() {
@@ -72,6 +76,30 @@ public class ObjectCopyOptions {
         this.headers.put(key, value);
         return this;
     }
+
+    /**
+     * Sets a header which indicates when the copy should be deleted
+     * @param date The date after which the copy should be deleted
+     * @return ObjectCopyOptions
+     */
+    public ObjectCopyOptions deleteAt(Date date) {
+        return this.header("X-Delete-At", Long.toString(TimeUnit.MILLISECONDS.toSeconds(date.getTime())));
+    }
+
+    /**
+     * Sets an header which indicates after which period of time the copy should be deleted
+     * @param t the delay
+     * @param unit the unit of the delay
+     * @return ObjectCopyOptions
+     */
+    public ObjectCopyOptions deleteAfter(long t, TimeUnit unit) {
+        final long secs = unit.toSeconds(t);
+        if(secs < 1) {
+            throw new IllegalArgumentException("TTL has to be at least 1 seconds (" + t + " " + unit + ")");
+        }
+        return this.header("X-Delete-After", Long.toString(secs));
+    }
+
 
     public Map<String, String> getHeaders() {
         return headers;

--- a/core/src/main/java/org/openstack4j/model/storage/object/options/ObjectCopyOptions.java
+++ b/core/src/main/java/org/openstack4j/model/storage/object/options/ObjectCopyOptions.java
@@ -1,0 +1,80 @@
+package org.openstack4j.model.storage.object.options;
+
+import com.google.common.collect.Maps;
+import org.openstack4j.openstack.storage.object.functions.MetadataToHeadersFunction;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+
+import static org.openstack4j.model.storage.object.SwiftHeaders.CONTENT_TYPE;
+import static org.openstack4j.model.storage.object.SwiftHeaders.OBJECT_METADATA_PREFIX;
+
+/**
+ * Options used for copying objects
+ *
+ * @author Lukas Alt
+ */
+public class ObjectCopyOptions {
+    private final Map<String, String> headers = Maps.newHashMap();
+
+    private ObjectCopyOptions() {
+
+    }
+
+    public static ObjectCopyOptions create() {
+        return new ObjectCopyOptions();
+    }
+
+    /**
+     * Specifies the MIME type/Content Type of the uploaded payload
+     *
+     * @param contentType the content type/mime type
+     * @return ObjectCopyOptions
+     */
+    public ObjectCopyOptions contentType(String contentType) {
+        headers.put(CONTENT_TYPE, contentType);
+        return this;
+    }
+
+    @Nullable
+    public String getContentType() {
+        return headers.get(CONTENT_TYPE);
+    }
+
+    /**
+     * Additional metadata associated with the Object
+     *
+     * @param metadata the metadata
+     * @return ObjectPutOptions
+     */
+    public ObjectCopyOptions metadata(Map<String, String> metadata) {
+        this.headers.putAll(MetadataToHeadersFunction.create(OBJECT_METADATA_PREFIX).apply(metadata));
+        return this;
+    }
+
+    /**
+     *
+     * @param headers map containing headers to add
+     * @return ObjectCopyOptions
+     */
+    public ObjectCopyOptions headers(Map<String, String> headers) {
+        this.headers.putAll(headers);
+        return this;
+    }
+
+    /**
+     * Sets the specified header
+     * @param key The key of the header
+     * @param value The value of the header
+     * @return ObjectCopyOptions
+     */
+    public ObjectCopyOptions header(String key, String value) {
+        this.headers.put(key, value);
+        return this;
+    }
+
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
+}

--- a/core/src/main/java/org/openstack4j/model/storage/object/options/ObjectPutOptions.java
+++ b/core/src/main/java/org/openstack4j/model/storage/object/options/ObjectPutOptions.java
@@ -1,8 +1,10 @@
 package org.openstack4j.model.storage.object.options;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import com.google.common.collect.Maps;
 import org.openstack4j.openstack.storage.object.functions.MetadataToHeadersFunction;
@@ -82,6 +84,42 @@ public final class ObjectPutOptions {
             queryParams.put(key, list);
         }
         return this;
+    }
+
+
+    /**
+     * Sets the specified header
+     * @param key The key of the header
+     * @param value The value of the header
+     * @return ObjectCopyOptions
+     */
+    public ObjectPutOptions header(String key, String value) {
+        this.headers.put(key, value);
+        return this;
+    }
+
+
+    /**
+     * Sets a header which indicates when the copy should be deleted
+     * @param date The date after which the copy should be deleted
+     * @return ObjectCopyOptions
+     */
+    public ObjectPutOptions deleteAt(Date date) {
+        return this.header("X-Delete-At", Long.toString(TimeUnit.MILLISECONDS.toSeconds(date.getTime())));
+    }
+
+    /**
+     * Sets an header which indicates after which period of time the copy should be deleted
+     * @param t the delay
+     * @param unit the unit of the delay
+     * @return ObjectCopyOptions
+     */
+    public ObjectPutOptions deleteAfter(long t, TimeUnit unit) {
+        final long secs = unit.toSeconds(t);
+        if(secs < 1) {
+            throw new IllegalArgumentException("TTL has to be at least 1 seconds (" + t + " " + unit + ")");
+        }
+        return this.header("X-Delete-After", Long.toString(secs));
     }
 
     public Map<String, List<Object>> getQueryParams() {

--- a/core/src/main/java/org/openstack4j/openstack/storage/object/internal/ObjectStorageObjectServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/object/internal/ObjectStorageObjectServiceImpl.java
@@ -13,10 +13,7 @@ import org.openstack4j.model.common.Payload;
 import org.openstack4j.model.common.payloads.FilePayload;
 import org.openstack4j.model.storage.block.options.DownloadOptions;
 import org.openstack4j.model.storage.object.SwiftObject;
-import org.openstack4j.model.storage.object.options.ObjectDeleteOptions;
-import org.openstack4j.model.storage.object.options.ObjectListOptions;
-import org.openstack4j.model.storage.object.options.ObjectLocation;
-import org.openstack4j.model.storage.object.options.ObjectPutOptions;
+import org.openstack4j.model.storage.object.options.*;
 import org.openstack4j.openstack.common.DLPayloadEntity;
 import org.openstack4j.openstack.common.functions.HeaderNameValuesToHeaderMap;
 import org.openstack4j.openstack.storage.object.domain.SwiftObjectImpl;
@@ -159,12 +156,22 @@ public class ObjectStorageObjectServiceImpl extends BaseObjectStorageService imp
      */
     @Override
     public String copy(ObjectLocation source, ObjectLocation dest) {
+        return copy(source, dest, ObjectCopyOptions.create());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String copy(ObjectLocation source, ObjectLocation dest, ObjectCopyOptions options) {
         checkNotNull(source);
         checkNotNull(dest);
+        checkNotNull(options);
 
         HttpResponse resp = put(Void.class, dest.getURI())
                 .header(X_COPY_FROM, source.getURI())
                 .header(CONTENT_LENGTH, 0)
+                .headers(options.getHeaders())
                 .executeWithResponse();
         try {
             return resp.header(ETAG);

--- a/core/src/main/java/org/openstack4j/openstack/storage/object/internal/ObjectStorageObjectServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/object/internal/ObjectStorageObjectServiceImpl.java
@@ -156,7 +156,7 @@ public class ObjectStorageObjectServiceImpl extends BaseObjectStorageService imp
      */
     @Override
     public String copy(ObjectLocation source, ObjectLocation dest) {
-        return copy(source, dest, ObjectCopyOptions.create());
+        return copy(source, dest, ObjectCopyOptions.NONE);
     }
 
     /**

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -49,7 +49,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>1.3.3</version>
+                <version>3.2.3</version>
                 <executions>
                     <execution>
                         <id>withdeps-shade</id>

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
         <maven.jar.plugin.version>2.6</maven.jar.plugin.version>
         <maven.source.plugin.version>2.4</maven.source.plugin.version>
         <maven.javadoc.plugin.version>2.10.4</maven.javadoc.plugin.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <additionalparam>-Xdoclint:none</additionalparam>
     </properties>


### PR DESCRIPTION
Currently, the API supports copying one object to another location within an OpenStack instance. For this purpose, the PUT operation is used and the source object location is specified using the `X-Copy-From` header (https://docs.openstack.org/api-ref/object-store/?expanded=copy-object-detail#copy-object). 

In addition, OpenStack allows specifying different options using headers, e.g. `X-Delete-After` can be used to set a TTL for an object. For similar operations (like PUT), these headers can be set using the ObjectPutOptions but there is currently no way to do this for the copy operation.

This pr introduces an optional argument of the type ObjectCopyOptions for the copy() option the same way it is implemented for the other operations.
Furthermore, I've added methods for specifying the TTL without explicitly setting the headers.

In addition, I've updated the version of the shade plugin as this significantly speeds up the building process.

I don't think unit tests are applicable here but I have tested my changes manually against OVH OpenStack.

