### PR TITLE
Keystone: Support Multi-Factor Authentication with TOTP #162

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,11 @@ script:
         set -x
         # TRAVIS_BRANCH is name of the branch built OR the name of the target branch in case of PRs
         if [ "$TRAVIS_BRANCH" == "master" -a -z "$TRAVIS_PULL_REQUEST_BRANCH" ]; then
-          echo "Run sonar analysis for master only"
+          echo "Run jacoco analysis for master only"
           jacoco_goal="org.jacoco:jacoco-maven-plugin:prepare-agent"
-          sonar_goal="org.sonarsource.scanner.maven:sonar-maven-plugin:3.7.0.1746:sonar"
-          sonar_opts="-Dsonar.projectKey=openstack4j_openstack4j"
+          # disable sonar due to java 11 requirement
+          # sonar_goal="org.sonarsource.scanner.maven:sonar-maven-plugin:3.7.0.1746:sonar"
+          # sonar_opts="-Dsonar.projectKey=openstack4j_openstack4j"
         else
           echo "Skipping sonar analysis"
         fi

--- a/connectors/jersey2/pom.xml
+++ b/connectors/jersey2/pom.xml
@@ -11,14 +11,14 @@
     <packaging>jar</packaging>
 
     <properties>
-        <jersey-client-version>2.22.1</jersey-client-version>
+        <jersey-version>2.35</jersey-version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
-            <version>${jersey-client-version}</version>
+            <version>${jersey-version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -28,7 +28,12 @@
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-jackson</artifactId>
-            <version>2.11</version>
+            <version>${jersey-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+            <version>${jersey-version}</version>
         </dependency>
     </dependencies>
 

--- a/connectors/jersey2/src/main/java/org/openstack4j/connectors/jersey2/HttpCommand.java
+++ b/connectors/jersey2/src/main/java/org/openstack4j/connectors/jersey2/HttpCommand.java
@@ -14,7 +14,7 @@ import java.util.logging.Logger;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.client.HttpUrlConnectorProvider;
 import org.glassfish.jersey.client.RequestEntityProcessing;
-import org.glassfish.jersey.filter.LoggingFilter;
+import org.glassfish.jersey.logging.LoggingFeature;
 import org.openstack4j.core.transport.ClientConstants;
 import org.openstack4j.core.transport.HttpRequest;
 import org.openstack4j.core.transport.internal.HttpLoggingFilter;
@@ -54,7 +54,7 @@ public final class HttpCommand<R> {
         WebTarget target = client.target(request.getEndpoint()).path(request.getPath());
 
         if (HttpLoggingFilter.isLoggingEnabled())
-            target.register(new LoggingFilter(Logger.getLogger("os"), 10000));
+            target.register(new LoggingFeature(Logger.getLogger("os"), 10000));
 
         target = populateQueryParams(target, request);
         invocation = target.request(MediaType.APPLICATION_JSON);

--- a/core-integration-test/pom.xml
+++ b/core-integration-test/pom.xml
@@ -37,6 +37,12 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>dev.samstevens.totp</groupId>
+            <artifactId>totp</artifactId>
+            <version>1.7.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.13.1</version>

--- a/core-integration-test/src/test/groovy/org/openstack4j/api/AbstractSpec.groovy
+++ b/core-integration-test/src/test/groovy/org/openstack4j/api/AbstractSpec.groovy
@@ -1,12 +1,11 @@
 package org.openstack4j.api
 
 import groovy.util.logging.Slf4j
+import java.nio.file.Paths
 import org.openstack4j.core.transport.Config
 import org.openstack4j.core.transport.ProxyHost
 import org.openstack4j.core.transport.internal.HttpExecutor
 import spock.lang.Specification
-
-import java.nio.file.Paths
 
 @Slf4j
 abstract class AbstractSpec extends Specification {
@@ -22,6 +21,8 @@ abstract class AbstractSpec extends Specification {
     def static String USER_ID = System.getenv('OS_USER_ID') ?: '71a7dcb0d60a43088a6c8e9b69a39e69'
     def static String USER_NAME = System.getenv('OS_USERNAME') ?: 'admin'
     def static String USER_DOMAIN_ID = System.getenv('OS_USER_DOMAIN_ID') ?: DOMAIN_ID
+    def static String USER_TOTP_SECRET = System.getenv('OS_USER_TOTP_SECRET')
+    def static String USER_TOTP_PASSCODE = System.getenv('OS_USER_TOTP_PASSCODE') ?: '123456'
     def static String AUTH_URL = System.getenv('OS_AUTH_URL') ?: 'http://devstack.openstack.stack:5000/v3'
     def static String PASSWORD = System.getenv('OS_PASSWORD') ?: 'devstack'
     def static String PROJECT_ID = System.getenv('OS_PROJECT_ID') ?: '194dfdddb6bc43e09701035b52edb0d9'

--- a/core-integration-test/src/test/resources/tapes/identity.v3/authenticate_v3_userId_password_passcode_projectName_projectDomainId.yaml
+++ b/core-integration-test/src/test/resources/tapes/identity.v3/authenticate_v3_userId_password_passcode_projectName_projectDomainId.yaml
@@ -1,0 +1,109 @@
+!tape
+name: authenticate_v3_userId_password_projectName_projectDomainId
+interactions:
+    -   recorded: 2021-09-17T19:52:51.379Z
+        request:
+            method: POST
+            uri: http://devstack.openstack.stack:5000/v3/auth/tokens
+            headers:
+                Accept: application/json
+                Content-Length: '12523'
+                Content-Type: application/json
+                Host: devstack.openstack.stack:5000
+                OS4J-Auth-Command: Tokens
+                Proxy-Connection: keep-alive
+                User-Agent: Jersey/2.22.1 (HttpUrlConnection 1.8.0_60)
+            body: |-
+                {
+                    "identity": {
+                        "password": {
+                            "user": {
+                                "name": "admin",
+                                "domain": {
+                                    "name": "default"
+                                },
+                                "password": "devstack"
+                            }
+                        },
+                        "totp": {
+                            "user": {
+                                "name": "admin",
+                                "passcode": "123456",
+                                "domain": {
+                                    "name": "default"
+                                }
+                            }
+                        },
+                        "methods": [
+                                "password",
+                                "totp"
+                        ]
+                    },
+                    "scope": {
+                        "project": {
+                            "id": "194dfdddb6bc43e09701035b52edb0d9"
+                        }
+                    }
+                }
+        response:
+            status: 201
+            headers:
+                Content-Type: application/json
+                Date: Fri, 17 Sep 2021 17:02:34 GMT
+                Server: nginx/1.10.3 (Ubuntu)
+                Vary: X-Auth-Token
+                X-Subject-Token: gAAAAABhRMoqEnuulgXlf-C0Txss9nrfYMLhrcMAWKWq_kq_9FiwihSxXoHvOKTswGNF0mYuGrif9N0GG0dRvTYM-No_Dl89g6to3J-A6fS6XGCZhqfXDbwgIHfA0FxInEXX-E7jFCyWBbgcEjdQrOoJoO95rZ9ZreKYNraRtD6AVf2Avnnn4jE
+                x-openstack-request-id: req-19aab02a-b1fc-45b2-9080-d634dc93ddf3
+            body: '{
+          "token": {
+            "is_domain": false,
+            "methods": [
+              "password",
+              "totp"
+            ],
+            "roles": [
+              {
+                "id": "9fe2ff9ee4384b1894a90878d3e92bab",
+                "name": "Member"
+              }
+            ],
+            "expires_at": "2021-09-21T10:18:27.000000Z",
+            "project": {
+              "domain": {
+                "id": "5ad59bc8777347f78e111b3b8852f960",
+                "name": "Default"
+              },
+              "id": "eee5cb8a59d44009bc7a3393e55e9450",
+              "name": "admin"
+            },
+            "catalog": [
+              {
+                "endpoints": [
+                  {
+                    "region_id": "de-nbg6-1",
+                    "url": "http://devstack.openstack.stack:9311",
+                    "region": "RegionOne",
+                    "interface": "admin",
+                    "id": "5f00d8587c144b1cb47fc9385333d0cd"
+                  }
+                ],
+                "type": "key-manager",
+                "id": "03328af2c19d4f188083412185c32063",
+                "name": "barbican"
+              }
+            ],
+            "user": {
+              "password_expires_at": null,
+              "domain": {
+                "id": "5ad59bc8777347f78e111b3b8852f960",
+                "name": "Default"
+              },
+              "id": "f90cf1a2f02648bfa5bf6ff5ea2e8c93",
+              "name": "admin"
+            },
+            "audit_ids": [
+              "iDSSDj_zQL6FI-U1cjBtsw"
+            ],
+            "issued_at": "2021-09-20T10:18:27.000000Z"
+          }
+        }'

--- a/core-test/src/main/java/org/openstack4j/api/identity/v3/KeystoneAuthenticationTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/identity/v3/KeystoneAuthenticationTests.java
@@ -2,6 +2,7 @@ package org.openstack4j.api.identity.v3;
 
 import java.util.List;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import org.openstack4j.api.AbstractTest;
 import org.openstack4j.api.OSClient.OSClientV3;
@@ -14,6 +15,7 @@ import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 /**
@@ -24,6 +26,7 @@ public class KeystoneAuthenticationTests extends AbstractTest {
 
     private static final String JSON_AUTH_PROJECT = "/identity/v3/authv3_project.json";
     private static final String JSON_AUTH_DOMAIN = "/identity/v3/authv3_domain.json";
+    private static final String JSON_AUTH_TOTP_DOMAIN = "/identity/v3/authv3_totp_project.json";
     private static final String JSON_AUTH_TOKEN = "/identity/v3/authv3_token.json";
     private static final String JSON_AUTH_TOKEN_UNSCOPED = "/identity/v3/authv3_token_unscoped.json";
     private static final String JSON_AUTH_UNSCOPED = "/identity/v3/authv3_unscoped.json";
@@ -147,6 +150,23 @@ public class KeystoneAuthenticationTests extends AbstractTest {
         assertEquals(osv3.getToken().getUser().getId(), USER_ID);
         assertEquals(osv3.getToken().getDomain().getId(), DOMAIN_ID);
 
+    }
+
+    public void authenticate_userName_password_totp_projectId_Test() throws Exception {
+
+        respondWith(JSON_AUTH_TOTP_DOMAIN);
+
+        associateClientV3(OSFactory.builderV3()
+                .endpoint(authURL("/v3"))
+                .credentials(USER_NAME, PASSWORD, Identifier.byId(DOMAIN_ID), "passcode")
+                .scopeToProject(Identifier.byId(PROJECT_ID))
+                .authenticate());
+
+        System.out.println(new ObjectMapper().writer().writeValueAsString(osv3));
+        assertEquals(osv3.getToken().getVersion(), AuthVersion.V3);
+        assertEquals(osv3.getToken().getUser().getId(), USER_ID);
+        assertEquals(osv3.getToken().getProject().getId(), PROJECT_ID);
+        assertNull(osv3.getToken().getDomain());
     }
 
     /**

--- a/core-test/src/main/java/org/openstack4j/api/identity/v3/KeystoneAuthenticationTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/identity/v3/KeystoneAuthenticationTests.java
@@ -2,7 +2,6 @@ package org.openstack4j.api.identity.v3;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import org.openstack4j.api.AbstractTest;
 import org.openstack4j.api.OSClient.OSClientV3;
@@ -162,7 +161,6 @@ public class KeystoneAuthenticationTests extends AbstractTest {
                 .scopeToProject(Identifier.byId(PROJECT_ID))
                 .authenticate());
 
-        System.out.println(new ObjectMapper().writer().writeValueAsString(osv3));
         assertEquals(osv3.getToken().getVersion(), AuthVersion.V3);
         assertEquals(osv3.getToken().getUser().getId(), USER_ID);
         assertEquals(osv3.getToken().getProject().getId(), PROJECT_ID);

--- a/core-test/src/main/resources/identity/v3/authv3_totp_project.json
+++ b/core-test/src/main/resources/identity/v3/authv3_totp_project.json
@@ -1,0 +1,67 @@
+{
+    "token": {
+        "audit_ids": [
+            "3T2dc1CGQxyJsHdDu1xkcw"
+        ],
+        "catalog": [
+            {
+                "endpoints": [
+                    {
+                        "id": "068d1b359ee84b438266cb736d81de97",
+                        "interface": "public",
+                        "region": "RegionOne",
+                        "region_id": "RegionOne",
+                        "url": "http://example.com/identity"
+                    },
+                    {
+                        "id": "8bfc846841ab441ca38471be6d164ced",
+                        "interface": "admin",
+                        "region": "RegionOne",
+                        "region_id": "RegionOne",
+                        "url": "http://example.com/identity"
+                    },
+                    {
+                        "id": "beb6d358c3654b4bada04d4663b640b9",
+                        "interface": "internal",
+                        "region": "RegionOne",
+                        "region_id": "RegionOne",
+                        "url": "http://example.com/identity"
+                    }
+                ],
+                "type": "identity",
+                "id": "050726f278654128aba89757ae25950c",
+                "name": "keystone"
+            }
+        ],
+        "expires_at": "2015-11-07T02:58:43.578887Z",
+        "is_domain": false,
+        "issued_at": "2015-11-07T01:58:43.578929Z",
+        "methods": [
+            "password",
+            "totp"
+        ],
+        "project": {
+            "domain": {
+                "id": "default",
+                "name": "Default"
+            },
+            "id": "123ac695d4db400a9001b91bb3b8aa46",
+            "name": "admin"
+        },
+        "roles": [
+            {
+                "id": "aa9f25defa6d4cafb48466df83106065",
+                "name": "admin"
+            }
+        ],
+        "user": {
+            "domain": {
+                "id": "default",
+                "name": "Default"
+            },
+            "id": "aa9f25defa6d4cafb48466df83106065",
+            "name": "admin",
+            "password_expires_at": "2016-11-06T15:32:17.000000"
+        }
+    }
+}

--- a/core/src/main/java/org/openstack4j/api/client/IOSClientBuilder.java
+++ b/core/src/main/java/org/openstack4j/api/client/IOSClientBuilder.java
@@ -147,6 +147,17 @@ public interface IOSClientBuilder<R, T extends IOSClientBuilder<R, T>> {
         V3 credentials(String userName, String password, Identifier domain);
 
         /**
+         * The authentication credentials and default scoped domain
+         *
+         * @param userName the user name to authenticate with
+         * @param password the password to authenticate with
+         * @param domain the domain if using "default scoped"
+         * @param passcode the totp generated passcode for Multi-Factor Authentication
+         * @return self for method chaining
+         */
+        V3 credentials(String userName, String password, Identifier domain, String passcode);
+
+        /**
          * DEPRECATED: Please use
          * {@link #credentials(String, String, Identifier)
          * <p>

--- a/core/src/main/java/org/openstack4j/core/transport/internal/HttpExecutor.java
+++ b/core/src/main/java/org/openstack4j/core/transport/internal/HttpExecutor.java
@@ -3,6 +3,8 @@ package org.openstack4j.core.transport.internal;
 import java.util.Iterator;
 import java.util.ServiceLoader;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.openstack4j.api.exceptions.ConnectorNotFoundException;
 import org.openstack4j.api.exceptions.ResponseException;
 import org.openstack4j.core.transport.HttpExecutorService;
@@ -48,11 +50,21 @@ public class HttpExecutor {
      * Delegate to {@link HttpExecutorService#execute(HttpRequest)}
      */
     public <R> HttpResponse execute(HttpRequest<R> request) {
-
-        LOG.debug("Executing Request: {} {}", request.getMethod(), request.getUrl());
+        LOG.info("Executing Request: {} {}", request.getMethod(), request.getUrl());
+        if (request.hasJson()) {
+            LOG.info("Request json Content: {}", request.getJson());
+        } else {
+            try {
+                LOG.info("Request entity Content: {}", new ObjectMapper().writer().writeValueAsString(request.getEntity()));
+            } catch (JsonProcessingException e) {
+                e.printStackTrace();
+            }
+        }
+        LOG.info("Request Headers {}", request.getHeaders());
         try {
             return service().execute(request);
         } catch (ResponseException ex) {
+            ex.printStackTrace();
             ex.setRequestInfo(request);
             throw ex;
         }

--- a/core/src/main/java/org/openstack4j/core/transport/internal/HttpExecutor.java
+++ b/core/src/main/java/org/openstack4j/core/transport/internal/HttpExecutor.java
@@ -3,8 +3,6 @@ package org.openstack4j.core.transport.internal;
 import java.util.Iterator;
 import java.util.ServiceLoader;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.openstack4j.api.exceptions.ConnectorNotFoundException;
 import org.openstack4j.api.exceptions.ResponseException;
 import org.openstack4j.core.transport.HttpExecutorService;
@@ -50,21 +48,11 @@ public class HttpExecutor {
      * Delegate to {@link HttpExecutorService#execute(HttpRequest)}
      */
     public <R> HttpResponse execute(HttpRequest<R> request) {
-        LOG.info("Executing Request: {} {}", request.getMethod(), request.getUrl());
-        if (request.hasJson()) {
-            LOG.info("Request json Content: {}", request.getJson());
-        } else {
-            try {
-                LOG.info("Request entity Content: {}", new ObjectMapper().writer().writeValueAsString(request.getEntity()));
-            } catch (JsonProcessingException e) {
-                e.printStackTrace();
-            }
-        }
-        LOG.info("Request Headers {}", request.getHeaders());
+
+        LOG.debug("Executing Request: {} {}", request.getMethod(), request.getUrl());
         try {
             return service().execute(request);
         } catch (ResponseException ex) {
-            ex.printStackTrace();
             ex.setRequestInfo(request);
             throw ex;
         }

--- a/core/src/main/java/org/openstack4j/model/identity/v3/Authentication.java
+++ b/core/src/main/java/org/openstack4j/model/identity/v3/Authentication.java
@@ -30,10 +30,10 @@ public interface Authentication extends ModelEntity {
                 Domain getDomain();
 
                 String getPassword();
-
-                public interface Domain extends ResourceEntity {
-                }
             }
+        }
+
+        public interface Domain extends ResourceEntity {
         }
 
         public interface Totp {
@@ -43,6 +43,8 @@ public interface Authentication extends ModelEntity {
             public interface User extends ResourceEntity {
 
                 String getPasscode();
+
+                Domain getDomain();
             }
         }
 

--- a/core/src/main/java/org/openstack4j/model/identity/v3/Authentication.java
+++ b/core/src/main/java/org/openstack4j/model/identity/v3/Authentication.java
@@ -17,6 +17,8 @@ public interface Authentication extends ModelEntity {
 
         Token getToken();
 
+        Totp getTotp();
+
         List<String> getMethods();
 
         public interface Password {
@@ -31,6 +33,16 @@ public interface Authentication extends ModelEntity {
 
                 public interface Domain extends ResourceEntity {
                 }
+            }
+        }
+
+        public interface Totp {
+
+            User getUser();
+
+            public interface User extends ResourceEntity {
+
+                String getPasscode();
             }
         }
 

--- a/core/src/main/java/org/openstack4j/openstack/client/OSClientBuilder.java
+++ b/core/src/main/java/org/openstack4j/openstack/client/OSClientBuilder.java
@@ -1,6 +1,5 @@
 package org.openstack4j.openstack.client;
 
-import jdk.internal.joptsimple.internal.Strings;
 import org.openstack4j.api.OSClient.OSClientV2;
 import org.openstack4j.api.OSClient.OSClientV3;
 import org.openstack4j.api.client.CloudProvider;
@@ -169,16 +168,16 @@ public abstract class OSClientBuilder<R, T extends IOSClientBuilder<R, T>> imple
         @Override
         public OSClientV3 authenticate() throws AuthenticationException {
             // token based authentication
-            if (!Strings.isNullOrEmpty(tokenId))
+            if (tokenId != null && tokenId.length() > 0)
                 if (scope != null) {
                     return (OSClientV3) OSAuthenticator.invoke(new KeystoneAuth(tokenId, scope), endpoint, perspective, config, provider);
                 } else {
                     return (OSClientV3) OSAuthenticator.invoke(new KeystoneAuth(tokenId), endpoint, perspective, config, provider);
                 }
             // credential based authentication
-            if (!Strings.isNullOrEmpty(user)) {
+            if (user != null && user.length() > 0) {
                 KeystoneAuth keystoneAuth;
-                if (Strings.isNullOrEmpty(passcode)) {
+                if (passcode == null || passcode.isEmpty()) {
                     keystoneAuth = new KeystoneAuth(user, password, domain, scope);
                 } else {
                     //with totp multifactor authentication

--- a/core/src/main/java/org/openstack4j/openstack/client/OSClientBuilder.java
+++ b/core/src/main/java/org/openstack4j/openstack/client/OSClientBuilder.java
@@ -176,7 +176,7 @@ public abstract class OSClientBuilder<R, T extends IOSClientBuilder<R, T>> imple
                 }
             // credential based authentication
             if (user != null && user.length() > 0)
-                return (OSClientV3) OSAuthenticator.invoke(new KeystoneAuth(user, password, domain, scope), endpoint, perspective, config, provider);
+                return (OSClientV3) OSAuthenticator.invoke(new KeystoneAuth(user, password, domain, scope, passcode), endpoint, perspective, config, provider);
             // Use tokenless auth finally
             return (OSClientV3) OSAuthenticator.invoke(new KeystoneAuth(scope, Auth.Type.TOKENLESS), endpoint, perspective, config, provider);
         }

--- a/core/src/main/java/org/openstack4j/openstack/client/OSClientBuilder.java
+++ b/core/src/main/java/org/openstack4j/openstack/client/OSClientBuilder.java
@@ -130,6 +130,7 @@ public abstract class OSClientBuilder<R, T extends IOSClientBuilder<R, T>> imple
         Identifier domain;
         AuthScope scope;
         String tokenId;
+        String passcode;
 
         @Override
         public ClientV3 domainName(String domainName) {
@@ -145,9 +146,16 @@ public abstract class OSClientBuilder<R, T extends IOSClientBuilder<R, T>> imple
 
         @Override
         public ClientV3 credentials(String user, String password, Identifier domain) {
+            credentials(user, password, domain, null);
+            return this;
+        }
+
+        @Override
+        public ClientV3 credentials(String user, String password, Identifier domain, String passcode) {
             this.user = user;
             this.password = password;
             this.domain = domain;
+            this.passcode = passcode;
             return this;
         }
 

--- a/core/src/main/java/org/openstack4j/openstack/identity/v3/domain/KeystoneAuth.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/v3/domain/KeystoneAuth.java
@@ -1,6 +1,7 @@
 package org.openstack4j.openstack.identity.v3.domain;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -16,6 +17,8 @@ import org.openstack4j.openstack.common.BasicResourceEntity;
 import org.openstack4j.openstack.common.IdResourceEntity;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.openstack4j.openstack.common.Auth.Type.CREDENTIALS;
+import static org.openstack4j.openstack.common.Auth.Type.TOKEN;
 
 /**
  * Represents an v3 Auth object.
@@ -23,7 +26,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @JsonRootName("auth")
 public class KeystoneAuth implements Authentication, AuthStore {
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 8837823134060387955L;
     @JsonProperty
     private AuthIdentity identity;
     private AuthScope scope;
@@ -36,13 +39,13 @@ public class KeystoneAuth implements Authentication, AuthStore {
 
     public KeystoneAuth(String tokenId) {
         this.identity = AuthIdentity.createTokenType(tokenId);
-        this.type = Type.TOKEN;
+        this.type = TOKEN;
     }
 
     public KeystoneAuth(String tokenId, AuthScope scope) {
         this.identity = AuthIdentity.createTokenType(tokenId);
         this.scope = scope;
-        this.type = Type.TOKEN;
+        this.type = TOKEN;
     }
 
     public KeystoneAuth(String userId, String password) {
@@ -52,7 +55,13 @@ public class KeystoneAuth implements Authentication, AuthStore {
     public KeystoneAuth(String user, String password, Identifier domain, AuthScope scope) {
         this.identity = AuthIdentity.createCredentialType(user, password, domain);
         this.scope = scope;
-        this.type = Type.CREDENTIALS;
+        this.type = CREDENTIALS;
+    }
+
+    public KeystoneAuth(String user, String password, Identifier domain, AuthScope scope, String passcode) {
+        this.identity = AuthIdentity.createMfaCredentialType(user, password, domain, passcode);
+        this.scope = scope;
+        this.type = CREDENTIALS;
     }
 
     public KeystoneAuth(AuthScope scope, Type type) {
@@ -110,9 +119,10 @@ public class KeystoneAuth implements Authentication, AuthStore {
 
     public static final class AuthIdentity implements Identity, Serializable {
 
-        private static final long serialVersionUID = 1L;
+        private static final long serialVersionUID = -8563838155355541485L;
 
         private AuthPassword password;
+        private AuthTotp totp;
         private AuthToken token;
         private List<String> methods = Lists.newArrayList();
 
@@ -134,9 +144,22 @@ public class KeystoneAuth implements Authentication, AuthStore {
             return identity;
         }
 
+        static AuthIdentity createMfaCredentialType(String username, String password, Identifier domain, String passcode) {
+            AuthIdentity identity = new AuthIdentity();
+            identity.password = new AuthPassword(username, password, domain);
+            identity.totp = new AuthTotp(username, passcode);
+            identity.methods.addAll(Arrays.asList("password", "totp"));
+            return identity;
+        }
+
         @Override
         public Password getPassword() {
             return password;
+        }
+
+        @Override
+        public Totp getTotp() {
+            return totp;
         }
 
         @Override
@@ -151,7 +174,7 @@ public class KeystoneAuth implements Authentication, AuthStore {
 
         public static final class AuthToken implements Token, Serializable {
 
-            private static final long serialVersionUID = 1L;
+            private static final long serialVersionUID = 1935770288647712823L;
 
             @JsonProperty
             private String id;
@@ -171,7 +194,7 @@ public class KeystoneAuth implements Authentication, AuthStore {
 
         public static final class AuthPassword implements Password, Serializable {
 
-            private static final long serialVersionUID = 1L;
+            private static final long serialVersionUID = 8972613021102760104L;
 
             private AuthUser user;
 
@@ -189,7 +212,7 @@ public class KeystoneAuth implements Authentication, AuthStore {
 
             public static final class AuthUser extends BasicResourceEntity implements User {
 
-                private static final long serialVersionUID = 1L;
+                private static final long serialVersionUID = -4167608519825308470L;
 
                 private AuthDomain domain;
                 private String password;
@@ -222,8 +245,44 @@ public class KeystoneAuth implements Authentication, AuthStore {
 
                 public static final class AuthDomain extends BasicResourceEntity implements Domain {
 
-                    private static final long serialVersionUID = 1L;
+                    private static final long serialVersionUID = -2351227462530931791L;
 
+                }
+            }
+        }
+
+        public static final class AuthTotp extends BasicResourceEntity implements Totp {
+
+            private static final long serialVersionUID = -6562863874386663500L;
+
+            private AuthTotpUser user;
+
+            public AuthTotp() {
+            }
+
+            public AuthTotp(String username, String passcode) {
+                this.user = new AuthTotpUser(username, passcode);
+            }
+
+            @Override
+            public AuthTotpUser getUser() {
+                return user;
+            }
+
+            public static final class AuthTotpUser extends BasicResourceEntity implements Totp.User {
+                private String passcode;
+
+                public AuthTotpUser() {
+                }
+
+                public AuthTotpUser(String id, String passcode) {
+                    setId(id);
+                    this.passcode = passcode;
+                }
+
+                @Override
+                public String getPasscode() {
+                    return passcode;
                 }
             }
         }
@@ -231,7 +290,7 @@ public class KeystoneAuth implements Authentication, AuthStore {
 
     public static final class AuthScope implements Scope, Serializable {
 
-        private static final long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1101142581222192941L;
 
         @JsonProperty("project")
         private ScopeProject project;
@@ -284,7 +343,7 @@ public class KeystoneAuth implements Authentication, AuthStore {
 
         public static final class ScopeProject extends BasicResourceEntity implements Project {
 
-            private static final long serialVersionUID = 1L;
+            private static final long serialVersionUID = -2834855123690060228L;
             private AuthDomain domain;
             @JsonProperty
             private String id;
@@ -335,7 +394,7 @@ public class KeystoneAuth implements Authentication, AuthStore {
 
         public static final class AuthDomain extends BasicResourceEntity implements Domain {
 
-            private static final long serialVersionUID = 1L;
+            private static final long serialVersionUID = -5768566757928958611L;
 
             @JsonProperty
             private String id;
@@ -362,7 +421,7 @@ public class KeystoneAuth implements Authentication, AuthStore {
 
         public static final class ScopeTrust extends IdResourceEntity {
 
-            private static final long serialVersionUID = 1L;
+            private static final long serialVersionUID = -4572825712927854311L;
 
             public ScopeTrust(String id) {
                 this.setId(id);

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <release.version>2.0.0</release.version>
         <aries.spifly.version>1.0.0</aries.spifly.version>
         <slf4j.version>1.7.21</slf4j.version>
-        <jackson.version>2.13.4.1</jackson.version>
+        <jackson.version>2.14.1</jackson.version>
         <maven.jar.plugin.version>2.6</maven.jar.plugin.version>
         <maven.source.plugin.version>2.4</maven.source.plugin.version>
         <maven.javadoc.plugin.version>2.10.4</maven.javadoc.plugin.version>
@@ -54,6 +54,11 @@
         <module>distribution</module>
     </modules>
     <dependencies>
+	<dependency>
+		<groupId>org.apache.felix</groupId>
+		<artifactId>maven-bundle-plugin</artifactId>
+		<version>5.1.8</version>
+	</dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
@@ -229,7 +234,7 @@
                                             maven-bundle-plugin
                                         </artifactId>
                                         <versionRange>
-                                            [2.5.3,)
+                                            [5.1.8,)
                                         </versionRange>
                                         <goals>
                                             <goal>manifest</goal>


### PR DESCRIPTION
# PR description

- This PR implements the issue https://github.com/openstack4j/openstack4j/issues/162
- Provides a workaround for https://github.com/openstack4j/openstack4j/issues/150 by disabling sonar until Java 11 is used
- update jersey version

I am currently struggling to create a valid Betamax tape, but i could test the totp authentication with an openstack environment.

> # Issue description
> At our companies openstack environment we need to activate multifactor authentication(mfa) via totp for additional security.
> Currently the openstack4j library has no support for mfa to use the authentication api with a totp passcode either with [multi-step-authentication](https://docs.openstack.org/api-ref/identity/v3/?expanded=multi-step-authentication-2-factor-password-and-totp-example-detail#multi-step-authentication-2-factor-password-and-totp-example) or [single-step authentication](https://docs.openstack.org/keystone/latest/user/multi-factor-authentication.html).
> Therefore we would like the extend the [org.openstack4j.api.client.IOSClientBuilder.V3](https://github.com/Farix1337/openstack4j/blob/a7f3265cfde2031a164defc0aab88fb4e3cb870f/core/src/main/java/org/openstack4j/api/client/IOSClientBuilder.java#L158-L158) and [org.openstack4j.model.identity.v3.Authentication](https://github.com/Farix1337/openstack4j/blob/a7f3265cfde2031a164defc0aab88fb4e3cb870f/core/src/main/java/org/openstack4j/model/identity/v3/Authentication.java#L39-L39) to allow the additional input of an optional totp passcode.
> A first draft of this extension is currently work in progress at https://github.com/Farix1337/openstack4j and the provided github links are already referencing the extension.
> Additional Tests are still missing, therefore no pull request was created yet.
> Me and my two colleagues(@MintInfusion and @frkautz) would like to provide this feature if allowed.
> 
> ## Submitter checklist
> Make sure that following is specified to make the issue easier to process:
> 
> * [x]  The issue description links to OpenStack API documentation of that particular endpoint/request (https://docs.openstack.org/api-quick-start/#current-api-versions).
> * [x]  OpenStack service name is used as an issue name prefix (ex.: "Neutron: Add floatingIp port forwardings service").
> * [x]  If applicable, add GitHub link to classes that needs extending.




## Submitter checklist

Make sure that following is addressed to make the PR easier to process:

- [x] If applicable, changes are covered by either a unit or a functional test.
- [x] If applicable, changes ware verified manually against an OpenStack instance.
- [x] If the change is API related, the PR description links to OpenStack API documentation of that particular endpoint/request (https://docs.openstack.org/api-quick-start/#current-api-versions).
- [x] If the change concerns particular OpenStack service, its name is used as a PR name prefix (ex.: "Neutron: Add floatingIp port forwardings service").
- [x] If the PR closes existing GitHub issue, PR name have prefix: `Fix #NNN: `.
