### PR TITLE
Neutron: Add Description field to SecurityRules

### DIFF
--- a/core/src/main/java/org/openstack4j/model/network/SecurityGroupRule.java
+++ b/core/src/main/java/org/openstack4j/model/network/SecurityGroupRule.java
@@ -81,5 +81,12 @@ public interface SecurityGroupRule extends ModelEntity, Buildable<NetSecurityGro
      */
     String getTenantId();
 
+    /**
+     * Gets A human-readable description.
+     *
+     * @return the description
+     */
+    String getDescription();
+
 
 }

--- a/core/src/main/java/org/openstack4j/model/network/builder/NetSecurityGroupRuleBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/network/builder/NetSecurityGroupRuleBuilder.java
@@ -31,7 +31,7 @@ public interface NetSecurityGroupRuleBuilder extends Builder<NetSecurityGroupRul
     NetSecurityGroupRuleBuilder direction(String direction);
 
     /**
-     * @see SecurityGroupRule#getEthertype()
+     * @see SecurityGroupRule#getEtherType()
      */
     NetSecurityGroupRuleBuilder ethertype(String ethertype);
 
@@ -59,5 +59,9 @@ public interface NetSecurityGroupRuleBuilder extends Builder<NetSecurityGroupRul
      * @see SecurityGroupRule#getRemoteIpPrefix()
      */
     NetSecurityGroupRuleBuilder remoteIpPrefix(String prefix);
+    /**
+     * @see SecurityGroupRule#getDescription()
+     */
+    NetSecurityGroupRuleBuilder description(String description);
 
 }

--- a/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronSecurityGroupRule.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronSecurityGroupRule.java
@@ -49,6 +49,9 @@ public class NeutronSecurityGroupRule implements SecurityGroupRule {
     @JsonProperty("remote_group_id")
     private String remoteGroupId;
 
+    @JsonProperty("description")
+    private String description;
+
     public static NetSecurityGroupRuleBuilder builder() {
         return new SecurityGroupRuleConcreteBuilder();
     }
@@ -140,6 +143,13 @@ public class NeutronSecurityGroupRule implements SecurityGroupRule {
     public String getSecurityGroupId() {
         return this.securityGroupId;
     }
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getDescription() {
+        return this.description;
+    }
 
     /**
      * {@inheritDoc}
@@ -156,6 +166,7 @@ public class NeutronSecurityGroupRule implements SecurityGroupRule {
                 .add("protocol", protocol)
                 .add("remoteGroup", remoteGroupId)
                 .add("remoteIpPrefix", remoteIpPrefix)
+                .add("description", description)
                 .addValue("\n")
                 .toString();
     }
@@ -166,7 +177,7 @@ public class NeutronSecurityGroupRule implements SecurityGroupRule {
     @Override
     public int hashCode() {
         return java.util.Objects.hash(id, tenantId, securityGroupId, direction, etherType,
-                portRangeMin, portRangeMax, protocol, remoteGroupId, remoteIpPrefix);
+                portRangeMin, portRangeMax, protocol, remoteGroupId, remoteIpPrefix, description);
     }
 
     /**
@@ -189,7 +200,8 @@ public class NeutronSecurityGroupRule implements SecurityGroupRule {
                     java.util.Objects.equals(portRangeMax, that.portRangeMax) &&
                     java.util.Objects.equals(protocol, that.protocol) &&
                     java.util.Objects.equals(remoteGroupId, that.remoteGroupId) &&
-                    java.util.Objects.equals(remoteIpPrefix, that.remoteIpPrefix)) {
+                    java.util.Objects.equals(remoteIpPrefix, that.remoteIpPrefix) &&
+                    java.util.Objects.equals(description, that.description)) {
                 return true;
             }
         }
@@ -346,6 +358,15 @@ public class NeutronSecurityGroupRule implements SecurityGroupRule {
         @Override
         public NetSecurityGroupRuleBuilder remoteIpPrefix(String prefix) {
             r.remoteIpPrefix = prefix;
+            return this;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public NetSecurityGroupRuleBuilder description(String description) {
+            r.description = description;
             return this;
         }
     }


### PR DESCRIPTION
# PR description

as it was already indicated in an issue in the old repo, the description field is missing in the security rules.
https://github.com/ContainX/openstack4j/issues/1290
with this PR i am submitting this feature/function.

Api doc: https://docs.openstack.org/api-ref/network/v2/index.html?expanded=show-security-group-rule-detail

## Submitter checklist

Make sure that following is addressed to make the PR easier to process:

- [X] If applicable, changes are covered by either a unit or a functional test.
- [X] If applicable, changes ware verified manually against an OpenStack instance.
- [X] If the change is API related, the PR description links to OpenStack API documentation of that particular endpoint/request (https://docs.openstack.org/api-quick-start/#current-api-versions).
- [X] If the change concerns particular OpenStack service, its name is used as a PR name prefix (ex.: "Neutron: Add floatingIp port forwardings service").
- [X] If the PR closes existing GitHub issue, PR name have prefix: `Fix #NNN: `.
