### PR TITLE
Neutron: add is_default to network

### DIFF
--- a/core/src/main/java/org/openstack4j/model/network/Network.java
+++ b/core/src/main/java/org/openstack4j/model/network/Network.java
@@ -2,6 +2,7 @@ package org.openstack4j.model.network;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.openstack4j.common.Buildable;
 import org.openstack4j.model.common.Resource;
 import org.openstack4j.model.common.TimeEntity;
@@ -78,4 +79,10 @@ public interface Network extends Resource, TimeEntity, Buildable<NetworkBuilder>
      * @return true if the port security enabled is shared
      */
     Boolean isPortSecurityEnabled();
+
+    /**
+     * @return true if the network is default pool
+     */
+    @JsonProperty("is_default")
+    boolean isDefault();
 }

--- a/core/src/main/java/org/openstack4j/model/network/NetworkUpdate.java
+++ b/core/src/main/java/org/openstack4j/model/network/NetworkUpdate.java
@@ -1,5 +1,6 @@
 package org.openstack4j.model.network;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.openstack4j.common.Buildable;
 import org.openstack4j.model.ModelEntity;
 import org.openstack4j.model.network.builder.NetworkUpdateBuilder;
@@ -32,4 +33,11 @@ public interface NetworkUpdate extends ModelEntity, Buildable<NetworkUpdateBuild
      */
     boolean isShared();
 
+    /**
+     * The network is default pool or not.
+     *
+     * @return true if is a default network
+     */
+    @JsonProperty("is_default")
+    boolean isDefault();
 }

--- a/core/src/main/java/org/openstack4j/model/network/builder/NetworkBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/network/builder/NetworkBuilder.java
@@ -55,9 +55,14 @@ public interface NetworkBuilder extends Builder<NetworkBuilder, Network> {
      * @see Network#getAvailabilityZoneHints()
      */
     NetworkBuilder addAvailabilityZoneHints(String availabilityZone);
-    
+
     /**
      * @see Network#isPortSecurityEnabled()
      */
     NetworkBuilder isPortSecurityEnabled(Boolean portSecurityEnabled);
+
+    /**
+     * @see Network#isDefault()
+     */
+    NetworkBuilder isDefault(Boolean isDefault);
 }

--- a/core/src/main/java/org/openstack4j/model/network/builder/NetworkUpdateBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/network/builder/NetworkUpdateBuilder.java
@@ -33,4 +33,12 @@ public interface NetworkUpdateBuilder extends Builder<NetworkUpdateBuilder, Netw
      * @return the builder
      */
     NetworkUpdateBuilder shared(boolean shared);
+
+    /**
+     * The network is default pool or not.
+     *
+     * @param isDefault if true the network is default
+     * @return the builder
+     */
+    NetworkUpdateBuilder isDefault(boolean isDefault);
 }

--- a/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronNetwork.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronNetwork.java
@@ -56,6 +56,8 @@ public class NeutronNetwork implements Network {
     private Date createdTime;
     @JsonProperty("updated_at")
     private Date updatedTime;
+    @JsonProperty("is_default")
+    private Boolean isDefault;
 
     /**
      * The maximum transmission unit (MTU) value to address fragmentation. Minimum value is 68 for IPv4, and 1280 for IPv6.
@@ -256,6 +258,14 @@ public class NeutronNetwork implements Network {
      * {@inheritDoc}
      */
     @Override
+    public boolean isDefault() {
+        return isDefault != null && isDefault;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public String toString() {
         return MoreObjects.toStringHelper(this).omitNullValues()
                 .add("name", name).add("status", status).add("subnets", subnets).add("provider:physical_network", providerPhyNet)
@@ -263,7 +273,7 @@ public class NeutronNetwork implements Network {
                 .add("id", id).add("shared", shared).add("provider:segmentation_id", providerSegID)
                 .add("mtu", mtu).add("availabilityZoneHints", availabilityZoneHints).add("availabilityZones", availabilityZones)
                 .add("portSecurityEnabled", portSecurityEnabled)
-                .add("created_at", createdTime).add("updated_at", updatedTime)
+                .add("created_at", createdTime).add("updated_at", updatedTime).add("isDefault", isDefault)
                 .toString();
     }
 
@@ -275,7 +285,7 @@ public class NeutronNetwork implements Network {
         return java.util.Objects.hash(name, status, subnets,
                 providerPhyNet, adminStateUp, tenantId, networkType,
                 routerExternal, id, shared, providerSegID, availabilityZoneHints, availabilityZones, portSecurityEnabled,
-                createdTime, updatedTime);
+                createdTime, updatedTime, isDefault);
     }
 
     /**
@@ -304,7 +314,8 @@ public class NeutronNetwork implements Network {
                     java.util.Objects.equals(availabilityZones, that.availabilityZones) &&
                     java.util.Objects.equals(portSecurityEnabled, that.portSecurityEnabled) &&
                     java.util.Objects.equals(createdTime, that.createdTime) &&
-                    java.util.Objects.equals(updatedTime, that.updatedTime)) {
+                    java.util.Objects.equals(updatedTime, that.updatedTime) &&
+                    java.util.Objects.equals(isDefault, that.isDefault)) {
                 return true;
             }
         }
@@ -402,10 +413,16 @@ public class NeutronNetwork implements Network {
             m.availabilityZoneHints.add(availabilityZone);
             return this;
         }
-        
+
         @Override
         public NetworkBuilder isPortSecurityEnabled(Boolean portSecurityEnabled) {
             m.portSecurityEnabled = portSecurityEnabled;
+            return this;
+        }
+
+        @Override
+        public NetworkBuilder isDefault(Boolean isDefault) {
+            m.isDefault = isDefault;
             return this;
         }
     }

--- a/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronNetworkUpdate.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronNetworkUpdate.java
@@ -23,6 +23,8 @@ public class NeutronNetworkUpdate implements NetworkUpdate {
     private Boolean shared;
     @JsonProperty("admin_state_up")
     private Boolean adminStateUp;
+    @JsonProperty("is_default")
+    private Boolean isDefault;
 
     public static NetworkUpdateBuilder builder() {
         return new NetworkUpdateConcreteBuilder();
@@ -50,10 +52,18 @@ public class NeutronNetworkUpdate implements NetworkUpdate {
         return shared == null ? false: shared;
     }
 
+    @JsonIgnore
+    @Override
+    public boolean isDefault() {
+        return isDefault == null ? false: isDefault;
+    }
+
+
+
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this).omitNullValues()
-                .add("name", name).add("adminStateUp", adminStateUp).add("shared", shared)
+                .add("name", name).add("adminStateUp", adminStateUp).add("shared", shared).add("isDefault", isDefault)
                 .toString();
     }
 
@@ -95,6 +105,12 @@ public class NeutronNetworkUpdate implements NetworkUpdate {
         @Override
         public NetworkUpdateBuilder shared(boolean shared) {
             model.shared = shared;
+            return this;
+        }
+
+        @Override
+        public NetworkUpdateBuilder isDefault(boolean isDefault) {
+            model.isDefault = isDefault;
             return this;
         }
 


### PR DESCRIPTION
# PR description

...

## Submitter checklist

this pr implements the is default flag on network level
Api Doc: https://docs.openstack.org/api-ref/network/v2/index.html?expanded=list-networks-detail,show-network-details-detail#networks
Make sure that following is addressed to make the PR easier to process:

- [] If applicable, changes are covered by either a unit or a functional test.
I get a ConcurrentModificationException when running the tests.
- [X] If applicable, changes ware verified manually against an OpenStack instance.
- [X] If the change is API related, the PR description links to OpenStack API documentation of that particular endpoint/request (https://docs.openstack.org/api-quick-start/#current-api-versions).
- [X] If the change concerns particular OpenStack service, its name is used as a PR name prefix (ex.: "Neutron: Add floatingIp port forwardings service").
- [X] If the PR closes existing GitHub issue, PR name have prefix: `Fix #NNN: `.
