### PR TITLE
Neutron: Add propagate_uplink_status to port creation

### DIFF
--- a/core-test/src/main/java/org/openstack4j/api/network/PortTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/network/PortTests.java
@@ -23,7 +23,8 @@ public class PortTests extends AbstractTest {
     private static final String JSON_PORT_EXTERNAL = "/network/port_external.json";
     private static final String NETWORK_ID = "a87cc70a-3e15-4acf-8205-9b711a3531b7";
     private static final Date DATE = new Date(1604096161000L);
-
+    private static final Boolean PROPAGATE_UPLINK_STATUS = true;
+    
     @Test
     public void createPorts() throws Exception {
         respondWith(JSON_PORTS_EXTERNAL);
@@ -47,11 +48,13 @@ public class PortTests extends AbstractTest {
         
         AllowedAddressPair allowedAddressPair = port.getAllowedAddressPairs().iterator().next();
         assertNotNull(allowedAddressPair.getIpAddress());
-        assertNotNull(allowedAddressPair.getMacAddress());        
+        assertNotNull(allowedAddressPair.getMacAddress());   
+        
+        assertEquals(port.isPropagateUplinkStatus(), PROPAGATE_UPLINK_STATUS);
     }
 
     private Port getPort() {
-        return Builders.port().networkId(NETWORK_ID).build();
+        return Builders.port().networkId(NETWORK_ID).portSecurityEnabled(PROPAGATE_UPLINK_STATUS).propagateUplinkStatus(PROPAGATE_UPLINK_STATUS).build();
     }
 
     private List<? extends Port> getPorts() {

--- a/core-test/src/main/resources/network/port_external.json
+++ b/core-test/src/main/resources/network/port_external.json
@@ -14,6 +14,7 @@
         "binding:vnic_type": "baremetal",
         "device_id": "d90a13da-be41-461f-9f99-1dbcf438fdf2",
         "device_owner": "baremetal:none",
+        "propagate_uplink_status":true,
         "allowed_address_pairs": [
             {
                    "ip_address": "192.168.0.100",

--- a/core-test/src/main/resources/network/ports_external.json
+++ b/core-test/src/main/resources/network/ports_external.json
@@ -26,6 +26,7 @@
             "security_groups": [
                 "f0ac4394-7e4a-4409-9701-ba8be283dbc3"
             ],
+            "propagate_uplink_status":true,
             "status": "DOWN",
             "tenant_id": "d6700c0c9ffa4f1cb322cd4a1f3906fa",
             "created_at": "2020-10-30T22:16:01Z",
@@ -57,6 +58,7 @@
             "security_groups": [
                 "f0ac4394-7e4a-4409-9701-ba8be283dbc3"
             ],
+            "propagate_uplink_status":true,
             "status": "DOWN",
             "tenant_id": "d6700c0c9ffa4f1cb322cd4a1f3906fa",
             "created_at": "2020-10-30T22:16:01Z",

--- a/core/src/main/java/org/openstack4j/model/network/Port.java
+++ b/core/src/main/java/org/openstack4j/model/network/Port.java
@@ -77,6 +77,11 @@ public interface Port extends Resource, TimeEntity, Buildable<PortBuilder> {
      * @return The port security status. A valid value is enabled (true) or disabled (false).
      */
     Boolean isPortSecurityEnabled();
+    
+    /**
+     * @return The uplink status propagation of the port. Valid values are enabled (true) and disabled (false).
+     */
+    Boolean isPropagateUplinkStatus();
 
     String getHostId();
 

--- a/core/src/main/java/org/openstack4j/model/network/builder/PortBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/network/builder/PortBuilder.java
@@ -128,6 +128,8 @@ public interface PortBuilder extends Builder<PortBuilder, Port> {
     PortBuilder securityGroup(String groupName);
 
     PortBuilder portSecurityEnabled(Boolean portSecurityEnabled);
+    
+    PortBuilder propagateUplinkStatus(Boolean propagateUplinkStatus);
 
     PortBuilder hostId(String hostId);
 

--- a/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronPort.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronPort.java
@@ -72,6 +72,9 @@ public class NeutronPort implements Port {
     @JsonProperty("port_security_enabled")
     private Boolean portSecurityEnabled;
 
+    @JsonProperty("propagate_uplink_status")
+    private Boolean propagateUplinkStatus;
+
     @JsonProperty("binding:host_id")
     private String hostId;
 
@@ -323,9 +326,12 @@ public class NeutronPort implements Port {
     public Boolean isPortSecurityEnabled() {
         return portSecurityEnabled;
     }
+    
+    public Boolean isPropagateUplinkStatus() {
+		return propagateUplinkStatus;
+	}
 
-
-    /**
+	/**
      * {@inheritDoc}
      */
     @Override
@@ -336,9 +342,9 @@ public class NeutronPort implements Port {
                 .add("deviceOwner", deviceOwner).add("fixedIps", fixedIps).add("macAddress", macAddress)
                 .add("networkId", networkId).add("tenantId", tenantId).add("securityGroups", securityGroups)
                 .add("allowed_address_pairs", allowedAddressPairs).add("port_security_enabled ", portSecurityEnabled)
-                .add("binding:host_id", hostId).add("binding:vif_type", vifType).add("binding:vif_details", vifDetails)
-                .add("binding:vnic_type", vNicType).add("binding:profile", profile)
-                .add("created_at", createdTime).add("updated_at", updatedTime)
+                .add("propagate_uplink_status ", propagateUplinkStatus).add("binding:host_id", hostId)
+                .add("binding:vif_type", vifType).add("binding:vif_details", vifDetails).add("binding:vnic_type", vNicType)
+                .add("binding:profile", profile).add("created_at", createdTime).add("updated_at", updatedTime)
                 .toString();
     }
 
@@ -349,7 +355,7 @@ public class NeutronPort implements Port {
     public int hashCode() {
         return java.util.Objects.hash(id, name, adminStateUp, deviceId,
                 deviceOwner, fixedIps, macAddress, networkId, tenantId,
-                securityGroups, allowedAddressPairs, portSecurityEnabled, hostId,
+                securityGroups, allowedAddressPairs, portSecurityEnabled, propagateUplinkStatus, hostId,
                 vifType, vifDetails, vNicType, profile, createdTime, updatedTime);
     }
 
@@ -376,6 +382,7 @@ public class NeutronPort implements Port {
                     java.util.Objects.equals(securityGroups, that.securityGroups) &&
                     java.util.Objects.equals(allowedAddressPairs, that.allowedAddressPairs) &&
                     java.util.Objects.equals(portSecurityEnabled, that.portSecurityEnabled) &&
+                    java.util.Objects.equals(propagateUplinkStatus , that.propagateUplinkStatus) &&
                     java.util.Objects.equals(hostId, that.hostId) &&
                     java.util.Objects.equals(vifType, that.vifType) &&
                     java.util.Objects.equals(vifDetails, that.vifDetails) &&
@@ -547,6 +554,12 @@ public class NeutronPort implements Port {
         @Override
         public PortBuilder portSecurityEnabled(Boolean portSecurityEnabled) {
             m.portSecurityEnabled = portSecurityEnabled;
+            return this;
+        }
+        
+        @Override
+        public PortBuilder propagateUplinkStatus(Boolean propagateUplinkStatus) {
+            m.propagateUplinkStatus = propagateUplinkStatus;
             return this;
         }
 

--- a/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronPortCreate.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronPortCreate.java
@@ -54,6 +54,9 @@ public class NeutronPortCreate implements ModelEntity {
 
     @JsonProperty("port_security_enabled")
     private Boolean portSecurityEnabled;
+    
+    @JsonProperty("propagate_uplink_status")
+    private Boolean propagateUplinkStatus;
 
     @JsonProperty("binding:host_id")
     private String hostId;
@@ -94,6 +97,7 @@ public class NeutronPortCreate implements ModelEntity {
         c.fixedIps = (Set<NeutronIP>) port.getFixedIps();
         c.allowedAddressPairs = (Set<NeutronAllowedAddressPair>) port.getAllowedAddressPairs();
         c.portSecurityEnabled = port.isPortSecurityEnabled();
+        c.propagateUplinkStatus = port.isPropagateUplinkStatus();
         c.hostId = port.getHostId();
         c.vifType = port.getVifType();
         c.vifDetails = port.getVifDetails();


### PR DESCRIPTION
# PR description

Add propagate_uplink_status to port creation
API doc: https://docs.openstack.org/api-ref/network/v2/index.html?expanded=create-port-detail#create-port

## Submitter checklist

Make sure that following is addressed to make the PR easier to process:

- [ ] If applicable, changes are covered by either a unit or a functional test.
- [ ] If applicable, changes ware verified manually against an OpenStack instance.
- [ ] If the change is API related, the PR description links to OpenStack API documentation of that particular endpoint/request (https://docs.openstack.org/api-quick-start/#current-api-versions).
- [ ] If the change concerns particular OpenStack service, its name is used as a PR name prefix (ex.: "Neutron: Add floatingIp port forwardings service").
- [ ] If the PR closes existing GitHub issue, PR name have prefix: `Fix #NNN: `.
