### PR TITLE
#102 fixing migration status enum so serializsation is not failing.

### DIFF
--- a/core/src/main/java/org/openstack4j/model/storage/block/Volume.java
+++ b/core/src/main/java/org/openstack4j/model/storage/block/Volume.java
@@ -155,7 +155,7 @@ public interface Volume extends ModelEntity, Buildable<VolumeBuilder> {
     }
 
     public enum MigrationStatus {
-        NONE, MIGRATING;
+        MIGRATING, ERROR, SUCCESS, COMPLETING, NONE, STARTING;
 
         @JsonCreator
         public static MigrationStatus fromValue(String migrationStatus) {


### PR DESCRIPTION
# PR description

Fix  #102 
 
Blockstorage/Volume: fixing migration status enum so serializsation is not failing. 
According to https://github.com/openstack/cinder/blob/393c2e4ad90c05ebf28cc3a2c65811d7e1e0bc18/cinder/objects/fields.py#L204
...

## Submitter checklist

Make sure that following is addressed to make the PR easier to process:

- [] If applicable, changes are covered by either a unit or a functional test.
- [x] If applicable, changes ware verified manually against an OpenStack instance.
- [ ] If the change is API related, the PR description links to OpenStack API documentation of that particular endpoint/request (https://docs.openstack.org/api-quick-start/#current-api-versions).
- [ ] If the change concerns particular OpenStack service, its name is used as a PR name prefix (ex.: "Neutron: Add floatingIp port forwardings service").
- [x ] If the PR closes existing GitHub issue, PR name have prefix: `Fix #102 : `.
