### PR TITLE
Add Support for Application Credential Athentication

### DIFF
--- a/core-test/src/main/java/org/openstack4j/api/identity/v3/KeystoneAuthenticationTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/identity/v3/KeystoneAuthenticationTests.java
@@ -25,23 +25,27 @@ public class KeystoneAuthenticationTests extends AbstractTest {
     private static final String JSON_AUTH_PROJECT = "/identity/v3/authv3_project.json";
     private static final String JSON_AUTH_DOMAIN = "/identity/v3/authv3_domain.json";
     private static final String JSON_AUTH_TOKEN = "/identity/v3/authv3_token.json";
+    private static final String JSON_AUTH_APPLICATION_CREDENTIAL = "/identity/v3/authv3_application_credential.json";
     private static final String JSON_AUTH_TOKEN_UNSCOPED = "/identity/v3/authv3_token_unscoped.json";
     private static final String JSON_AUTH_UNSCOPED = "/identity/v3/authv3_unscoped.json";
     private static final String JSON_AUTH_ERROR_401 = "/identity/v3/authv3_authorizationerror.json";
     private static final String JSON_USERS = "/identity/v3/users.json";
     private static final ImmutableMap<String, String> HEADER_AUTH_PROJECT_RESPONSE = ImmutableMap.of("X-Subject-Token", "763fd7e197ab4e00b2e6e0a8d22a8e87", "Content-Type", "application/json");
     private static final ImmutableMap<String, String> HEADER_AUTH_TOKEN_RESPONSE = ImmutableMap.of("X-Subject-Token", "3ecb5c2063904566be4b10406c0f7568", "Content-Type", "application/json");
+    private static final ImmutableMap<String, String> HEADER_AUTH_APPLICATION_CREDENTIAL_RESPONSE = ImmutableMap.of("X-Subject-Token", "7c2b6a2063904566be4b10406c0f6268", "Content-Type", "application/json");
     private static final ImmutableMap<String, String> HEADER_REAUTH_TOKEN_RESPONSE = ImmutableMap.of("X-Subject-Token", "3e3f7ec1180e4f1b8ca884d32e04ccfb", "Content-Type", "application/json");
     private static final ImmutableMap<String, String> HEADER_REAUTH_PROJECT_RESPONSE = ImmutableMap.of("X-Subject-Token", "8f57cce49fd04b3cb72afdf8c0445b87", "Content-Type", "application/json");
 
     private static final String USER_NAME = "admin";
     private static final String USER_ID = "aa9f25defa6d4cafb48466df83106065";
+    private static final String APPLICATION_ID = "56ff25defa6d4cafb48466d5a2c2b765";
     private static final String DOMAIN_ID = "default";
     private static final String DOMAIN_NAME = "Default";
     private static final String PROJECT_ID = "123ac695d4db400a9001b91bb3b8aa46";
     private static final String PROJECT_NAME = "admin";
     private static final String PROJECT_DOMAIN_ID = "default";
     private static final String PASSWORD = "test";
+    private static final String APPLICATION_SECRET = "test";
     private static final String REGION_EUROPE = "europe";
     private static final String TOKEN_UNSCOPED_ID = "3ecb5c2063904566be4b10406c0f7568";
 
@@ -196,6 +200,24 @@ public class KeystoneAuthenticationTests extends AbstractTest {
         assertTrue(newTokenId != tokenId);
         assertEquals(osv3.getToken().getVersion(), AuthVersion.V3);
         assertEquals(osv3.getToken().getProject().getId(), PROJECT_ID);
+    }
+
+    /**
+     * authenticates with an application credential
+     */
+    public void auth_application_credential_test() throws Exception {
+
+        respondWithHeaderAndResource(HEADER_AUTH_APPLICATION_CREDENTIAL_RESPONSE, 201, JSON_AUTH_APPLICATION_CREDENTIAL);
+
+        OSClientV3 client = OSFactory.builderV3()
+                .endpoint(authURL("/v3"))
+                .applicationCredentials(APPLICATION_ID, APPLICATION_SECRET)
+                .authenticate();
+
+        assertNotNull(client.getToken());
+        assertNotNull(client.getToken().getProject());
+        assertEquals(PROJECT_ID, client.getToken().getProject().getId());
+        assertEquals(USER_ID, client.getToken().getUser().getId());
     }
 
     /**

--- a/core-test/src/main/resources/identity/v3/authv3_application_credential.json
+++ b/core-test/src/main/resources/identity/v3/authv3_application_credential.json
@@ -1,0 +1,36 @@
+{
+    "token": {
+        "methods": [
+            "application_credential"
+        ],
+        "user": {
+            "domain": {
+                "id": "default",
+                "name": "Default"
+            },
+            "id": "aa9f25defa6d4cafb48466df83106065",
+            "name": "admin",
+            "password_expires_at": null
+        },
+        "audit_ids": [
+            "Oyr7mMaeT8S6vQOb0x-N7Q"
+        ],
+        "expires_at": "2022-03-23T11:50:16.000000Z",
+        "issued_at": "2022-03-23T10:50:16.000000Z",
+        "project": {
+            "domain": {
+                "id": "default",
+                "name": "Default"
+            },
+            "id": "123ac695d4db400a9001b91bb3b8aa46",
+            "name": "admin"
+        },
+        "is_domain": false,
+        "roles": [
+            {
+                "id": "2b0f6e9874f04cb5a316bf5d2a4a4f7d",
+                "name": "user"
+            }
+        ]
+    }
+}

--- a/core/src/main/java/org/openstack4j/api/client/IOSClientBuilder.java
+++ b/core/src/main/java/org/openstack4j/api/client/IOSClientBuilder.java
@@ -205,6 +205,14 @@ public interface IOSClientBuilder<R, T extends IOSClientBuilder<R, T>> {
          */
         V3 scopeToDomain(Identifier domain);
 
+        /**
+         * Use application credentials for authentication.
+         *
+         * @param applicationId the id of the application credentials
+         * @param applicationSecret the passcode of the application credentials
+         * @return self for method chaining
+         */
+        V3 applicationCredentials(String applicationId, String applicationSecret);
     }
 
 }

--- a/core/src/main/java/org/openstack4j/openstack/client/OSClientBuilder.java
+++ b/core/src/main/java/org/openstack4j/openstack/client/OSClientBuilder.java
@@ -130,6 +130,8 @@ public abstract class OSClientBuilder<R, T extends IOSClientBuilder<R, T>> imple
         Identifier domain;
         AuthScope scope;
         String tokenId;
+        String applicationId;
+        String applicationSecret;
 
         @Override
         public ClientV3 domainName(String domainName) {
@@ -159,6 +161,12 @@ public abstract class OSClientBuilder<R, T extends IOSClientBuilder<R, T>> imple
 
         @Override
         public OSClientV3 authenticate() throws AuthenticationException {
+            // application_credentials
+            if (applicationId != null && !applicationId.isEmpty()
+                    && applicationSecret != null && !applicationSecret.isEmpty()) {
+                return (OSClientV3) OSAuthenticator.invoke(new KeystoneAuth(user, password, domain, scope, Auth.Type.APPLICATION_CREDENTIALS), endpoint, perspective, config, provider);
+            }
+
             // token based authentication
             if (tokenId != null && tokenId.length() > 0)
                 if (scope != null) {
@@ -168,7 +176,7 @@ public abstract class OSClientBuilder<R, T extends IOSClientBuilder<R, T>> imple
                 }
             // credential based authentication
             if (user != null && user.length() > 0)
-                return (OSClientV3) OSAuthenticator.invoke(new KeystoneAuth(user, password, domain, scope), endpoint, perspective, config, provider);
+                return (OSClientV3) OSAuthenticator.invoke(new KeystoneAuth(user, password, domain, scope, Auth.Type.CREDENTIALS), endpoint, perspective, config, provider);
             // Use tokenless auth finally
             return (OSClientV3) OSAuthenticator.invoke(new KeystoneAuth(scope, Auth.Type.TOKENLESS), endpoint, perspective, config, provider);
         }
@@ -191,5 +199,11 @@ public abstract class OSClientBuilder<R, T extends IOSClientBuilder<R, T>> imple
             return this;
         }
 
+        @Override
+        public V3 applicationCredentials(String applicationId, String applicationSecret) {
+            this.applicationId = applicationId;
+            this.applicationSecret = applicationSecret;
+            return this;
+        }
     }
 }

--- a/core/src/main/java/org/openstack4j/openstack/client/OSClientBuilder.java
+++ b/core/src/main/java/org/openstack4j/openstack/client/OSClientBuilder.java
@@ -164,7 +164,7 @@ public abstract class OSClientBuilder<R, T extends IOSClientBuilder<R, T>> imple
             // application_credentials
             if (applicationId != null && !applicationId.isEmpty()
                     && applicationSecret != null && !applicationSecret.isEmpty()) {
-                return (OSClientV3) OSAuthenticator.invoke(new KeystoneAuth(user, password, domain, scope, Auth.Type.APPLICATION_CREDENTIALS), endpoint, perspective, config, provider);
+                return (OSClientV3) OSAuthenticator.invoke(new KeystoneAuth(applicationId, applicationSecret, domain, scope, Auth.Type.APPLICATION_CREDENTIALS), endpoint, perspective, config, provider);
             }
 
             // token based authentication

--- a/core/src/main/java/org/openstack4j/openstack/common/Auth.java
+++ b/core/src/main/java/org/openstack4j/openstack/common/Auth.java
@@ -4,6 +4,6 @@ import org.openstack4j.model.ModelEntity;
 
 public interface Auth extends ModelEntity {
 
-    public enum Type {CREDENTIALS, TOKEN, RAX_APIKEY, TOKENLESS}
+    public enum Type {CREDENTIALS, TOKEN, RAX_APIKEY, TOKENLESS, APPLICATION_CREDENTIALS}
 
 }

--- a/core/src/main/java/org/openstack4j/openstack/identity/v3/domain/KeystoneAuth.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/v3/domain/KeystoneAuth.java
@@ -53,7 +53,7 @@ public class KeystoneAuth implements Authentication, AuthStore {
         this.type = type;
         this.scope = scope;
 
-        if (this.type == Type.CREDENTIALS) {
+        if (this.type == Type.APPLICATION_CREDENTIALS) {
             this.identity = AuthIdentity.createApplicationType(userOrApplicationId, passcode);
         } else {
             this.identity = AuthIdentity.createCredentialType(userOrApplicationId, passcode, domain);

--- a/core/src/main/java/org/openstack4j/openstack/identity/v3/domain/KeystoneAuth.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/v3/domain/KeystoneAuth.java
@@ -121,7 +121,7 @@ public class KeystoneAuth implements Authentication, AuthStore {
         private AuthPassword password;
         private AuthToken token;
         private List<String> methods = Lists.newArrayList();
-        @JsonProperty("application_credentials")
+        @JsonProperty("application_credential")
         private ApplicationCredentials applicationCredentials;
 
         static AuthIdentity createTokenType(String tokenId) {

--- a/core/src/main/java/org/openstack4j/openstack/identity/v3/domain/KeystoneAuth.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/v3/domain/KeystoneAuth.java
@@ -46,13 +46,19 @@ public class KeystoneAuth implements Authentication, AuthStore {
     }
 
     public KeystoneAuth(String userId, String password) {
-        this(userId, password, null, null);
+        this(userId, password, null, null, Type.CREDENTIALS);
     }
 
-    public KeystoneAuth(String user, String password, Identifier domain, AuthScope scope) {
-        this.identity = AuthIdentity.createCredentialType(user, password, domain);
+    public KeystoneAuth(String userOrApplicationId, String passcode, Identifier domain, AuthScope scope, Type type) {
+        this.type = type;
         this.scope = scope;
-        this.type = Type.CREDENTIALS;
+
+        if (this.type == Type.CREDENTIALS) {
+            this.identity = AuthIdentity.createApplicationType(userOrApplicationId, passcode);
+        } else {
+            this.identity = AuthIdentity.createCredentialType(userOrApplicationId, passcode, domain);
+
+        }
     }
 
     public KeystoneAuth(AuthScope scope, Type type) {
@@ -115,6 +121,8 @@ public class KeystoneAuth implements Authentication, AuthStore {
         private AuthPassword password;
         private AuthToken token;
         private List<String> methods = Lists.newArrayList();
+        @JsonProperty("application_credentials")
+        private ApplicationCredentials applicationCredentials;
 
         static AuthIdentity createTokenType(String tokenId) {
             AuthIdentity identity = new AuthIdentity();
@@ -134,6 +142,13 @@ public class KeystoneAuth implements Authentication, AuthStore {
             return identity;
         }
 
+        static AuthIdentity createApplicationType(String userOrApplicationId, String passcode) {
+            AuthIdentity identity = new AuthIdentity();
+            identity.applicationCredentials = new ApplicationCredentials(userOrApplicationId, passcode);
+            identity.methods.add("application_credential");
+            return identity;
+        }
+
         @Override
         public Password getPassword() {
             return password;
@@ -147,6 +162,14 @@ public class KeystoneAuth implements Authentication, AuthStore {
         @Override
         public List<String> getMethods() {
             return methods;
+        }
+
+        public ApplicationCredentials getApplicationCredentials() {
+            return applicationCredentials;
+        }
+
+        public void setApplicationCredentials(ApplicationCredentials applicationCredentials) {
+            this.applicationCredentials = applicationCredentials;
         }
 
         public static final class AuthToken implements Token, Serializable {
@@ -225,6 +248,38 @@ public class KeystoneAuth implements Authentication, AuthStore {
                     private static final long serialVersionUID = 1L;
 
                 }
+            }
+        }
+
+        public static final class ApplicationCredentials implements Serializable {
+
+            private static final long serialVersionUID = 1L;
+
+            private String id;
+            private String secret;
+
+            public ApplicationCredentials() {
+            }
+
+            public ApplicationCredentials(String id, String secret) {
+                this.id = id;
+                this.secret = secret;
+            }
+
+            public String getSecret() {
+                return secret;
+            }
+
+            public void setSecret(String secret) {
+                this.secret = secret;
+            }
+
+            public String getId() {
+                return id;
+            }
+
+            public void setId(String id) {
+                this.id = id;
             }
         }
     }

--- a/core/src/main/java/org/openstack4j/openstack/internal/OSAuthenticator.java
+++ b/core/src/main/java/org/openstack4j/openstack/internal/OSAuthenticator.java
@@ -204,11 +204,10 @@ public class OSAuthenticator {
         } else {
             if (token.getProject() != null) {
                 token = token.applyContext(info.endpoint, new TokenAuth(token.getId(),
-                        auth.getScope().getProject().getName(), auth.getScope().getProject().getId()));
-
+                        token.getProject().getName(), token.getProject().getId()));
             } else if (token.getDomain() != null) {
                 token = token.applyContext(info.endpoint, new TokenAuth(token.getId(),
-                        auth.getScope().getDomain().getName(), auth.getScope().getDomain().getId()));
+                        token.getDomain().getName(), token.getDomain().getId()));
             } else {
                 token = token.applyContext(info.endpoint, new TokenAuth(token.getId(), null, null));
             }


### PR DESCRIPTION
# PR description

This PR adds support to authenticate at OpenStack using [application credentials](https://docs.openstack.org/keystone/queens/user/application_credentials.html).

## Submitter checklist

Make sure that following is addressed to make the PR easier to process:

- [x] If applicable, changes are covered by either a unit or a functional test.
- [x] If applicable, changes ware verified manually against an OpenStack instance.
- [x] If the change is API related, the PR description links to OpenStack API documentation of that particular endpoint/request (https://docs.openstack.org/api-quick-start/#current-api-versions).
- [x] If the change concerns particular OpenStack service, its name is used as a PR name prefix (ex.: "Neutron: Add floatingIp port forwardings service").
- [x] If the PR closes existing GitHub issue, PR name have prefix: `Fix #NNN: `.
