### PR TITLE
add network type GENEVE

### DIFF
--- a/core/src/main/java/org/openstack4j/model/network/NetworkType.java
+++ b/core/src/main/java/org/openstack4j/model/network/NetworkType.java
@@ -14,7 +14,8 @@ public enum NetworkType {
     FLAT,
     VLAN,
     VXLAN,
-    GRE;
+    GRE,
+    GENEVE;
 
     @JsonCreator
     public static NetworkType forValue(String value) {


### PR DESCRIPTION
Add the network type GENVE to the enum of network types

# PR description

...

## Submitter checklist


From the docs:
Generic Network Virtualization Encapsulation (GENEVE)[¶](https://docs.openstack.org/neutron/rocky/admin/intro-overlay-protocols.html#generic-network-virtualization-encapsulation-geneve)
Geneve is designed to recognize and accommodate changing capabilities and needs of different devices in network virtualization. It provides a framework for tunneling rather than being prescriptive about the entire system. Geneve defines the content of the metadata flexibly that is added during encapsulation and tries to adapt to various virtualization scenarios. It uses UDP as its transport protocol and is dynamic in size using extensible option headers. Geneve supports unicast, multicast, and broadcast.
https://docs.openstack.org/neutron/rocky/admin/intro-overlay-protocols.html

Make sure that following is addressed to make the PR easier to process:

- [ ] If applicable, changes are covered by either a unit or a functional test.
- [ ] If applicable, changes ware verified manually against an OpenStack instance.
- [ ] If the change is API related, the PR description links to OpenStack API documentation of that particular endpoint/request (https://docs.openstack.org/api-quick-start/#current-api-versions).
- [ ] If the change concerns particular OpenStack service, its name is used as a PR name prefix (ex.: "Neutron: Add floatingIp port forwardings service").
- [ ] If the PR closes existing GitHub issue, PR name have prefix: `Fix #NNN: `.
