### PR TITLE
Migrate from URL to URI

### DIFF
--- a/core-integration-test/src/test/groovy/org/openstack4j/api/identity/v3/KeystoneServiceEndpointServiceSpec.groovy
+++ b/core-integration-test/src/test/groovy/org/openstack4j/api/identity/v3/KeystoneServiceEndpointServiceSpec.groovy
@@ -39,7 +39,7 @@ class KeystoneServiceEndpointServiceSpec extends AbstractSpec {
     def static final String SERVICE_CRUD_DESCRIPTION_UPDATE = "A updated service used for tests."
     def static final String ENDPOINT_CRUD_NAME = "Endpoint_CRUD"
     def static final URI ENDPOINT_CRUD_URL = new URL("http", "devstack.openstack.stack", 5000, "/v3").toURI()
-    def static final URL ENDPOINT_CRUD_URL_UPDATE = new URL("http", "stack.openstack.devstack", 5000, "/v3");
+    def static final URI ENDPOINT_CRUD_URL_UPDATE = new URL("http", "stack.openstack.devstack", 5000, "/v3").toURI();
     def static final Facing ENDPOINT_CRUD_IFACE = Facing.ADMIN
     def static final String ENDPOINT_CRUD_REGIONID = "RegionOne"
     def String SERVICE_CRUD_ID

--- a/core-integration-test/src/test/groovy/org/openstack4j/api/identity/v3/KeystoneServiceEndpointServiceSpec.groovy
+++ b/core-integration-test/src/test/groovy/org/openstack4j/api/identity/v3/KeystoneServiceEndpointServiceSpec.groovy
@@ -38,7 +38,7 @@ class KeystoneServiceEndpointServiceSpec extends AbstractSpec {
     def static final String SERVICE_CRUD_DESCRIPTION = "A service used for tests."
     def static final String SERVICE_CRUD_DESCRIPTION_UPDATE = "A updated service used for tests."
     def static final String ENDPOINT_CRUD_NAME = "Endpoint_CRUD"
-    def static final URL ENDPOINT_CRUD_URL = new URL("http", "devstack.openstack.stack", 5000, "/v3")
+    def static final URI ENDPOINT_CRUD_URL = new URL("http", "devstack.openstack.stack", 5000, "/v3").toURI()
     def static final URL ENDPOINT_CRUD_URL_UPDATE = new URL("http", "stack.openstack.devstack", 5000, "/v3");
     def static final Facing ENDPOINT_CRUD_IFACE = Facing.ADMIN
     def static final String ENDPOINT_CRUD_REGIONID = "RegionOne"

--- a/core/src/main/java/org/openstack4j/api/identity/v3/ServiceEndpointService.java
+++ b/core/src/main/java/org/openstack4j/api/identity/v3/ServiceEndpointService.java
@@ -1,7 +1,6 @@
 package org.openstack4j.api.identity.v3;
 
 import java.net.URI;
-import java.net.URL;
 import java.util.List;
 
 import org.openstack4j.api.types.Facing;
@@ -85,7 +84,7 @@ public interface ServiceEndpointService extends RestService {
      * Creates a new endpoint
      *
      * @param name the name of the endpoint
-     * @param url the url of the endpont
+     * @param url the url of the endpoint
      * @param iface the interface type of the endpoint
      * @param regionId the region id of the region that contains the endpoint
      * @param serviceId the service id of the service the endpoint belongs to

--- a/core/src/main/java/org/openstack4j/api/identity/v3/ServiceEndpointService.java
+++ b/core/src/main/java/org/openstack4j/api/identity/v3/ServiceEndpointService.java
@@ -1,5 +1,6 @@
 package org.openstack4j.api.identity.v3;
 
+import java.net.URI;
 import java.net.URL;
 import java.util.List;
 
@@ -90,7 +91,7 @@ public interface ServiceEndpointService extends RestService {
      * @param serviceId the service id of the service the endpoint belongs to
      * @param enabled the enabled status of the endpoint
      */
-    Endpoint createEndpoint(String name, URL url, Facing iface, String regionId, String serviceId, boolean enabled);
+    Endpoint createEndpoint(String name, URI url, Facing iface, String regionId, String serviceId, boolean enabled);
 
     /**
      * Get details for an endpoint

--- a/core/src/main/java/org/openstack4j/model/identity/v3/Endpoint.java
+++ b/core/src/main/java/org/openstack4j/model/identity/v3/Endpoint.java
@@ -1,7 +1,6 @@
 package org.openstack4j.model.identity.v3;
 
 import java.net.URI;
-import java.net.URL;
 import java.util.Map;
 
 import org.openstack4j.api.types.Facing;

--- a/core/src/main/java/org/openstack4j/model/identity/v3/Endpoint.java
+++ b/core/src/main/java/org/openstack4j/model/identity/v3/Endpoint.java
@@ -1,5 +1,6 @@
 package org.openstack4j.model.identity.v3;
 
+import java.net.URI;
 import java.net.URL;
 import java.util.Map;
 
@@ -60,7 +61,7 @@ public interface Endpoint extends ModelEntity, Buildable<EndpointBuilder> {
     /**
      * @return the URL of the endpoint
      */
-    URL getUrl();
+    URI getUrl();
 
     /**
      * @return the Links of the endpoint

--- a/core/src/main/java/org/openstack4j/model/identity/v3/builder/EndpointBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/identity/v3/builder/EndpointBuilder.java
@@ -1,5 +1,6 @@
 package org.openstack4j.model.identity.v3.builder;
 
+import java.net.URI;
 import java.net.URL;
 import java.util.Map;
 
@@ -55,7 +56,7 @@ public interface EndpointBuilder extends Builder<EndpointBuilder, Endpoint> {
     /**
      * @see Endpoint#getUrl()
      */
-    EndpointBuilder url(URL url);
+    EndpointBuilder url(URI url);
 
     /**
      * @see Endpoint#getLinks()

--- a/core/src/main/java/org/openstack4j/model/identity/v3/builder/EndpointBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/identity/v3/builder/EndpointBuilder.java
@@ -1,7 +1,6 @@
 package org.openstack4j.model.identity.v3.builder;
 
 import java.net.URI;
-import java.net.URL;
 import java.util.Map;
 
 import org.openstack4j.api.types.Facing;

--- a/core/src/main/java/org/openstack4j/openstack/identity/internal/DefaultEndpointURLResolver.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/internal/DefaultEndpointURLResolver.java
@@ -139,7 +139,7 @@ public class DefaultEndpointURLResolver implements EndpointURLResolver {
 
                 for (org.openstack4j.model.identity.v3.Endpoint ep : service.getEndpoints()) {
 
-                    if (matches(ep, p))
+                    if (matches(ep, p) && (ep.getUrl().getScheme().matches("^https?$")))
                         return ep.getUrl().toString();
                 }
             }

--- a/core/src/main/java/org/openstack4j/openstack/identity/internal/DefaultEndpointURLResolver.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/internal/DefaultEndpointURLResolver.java
@@ -3,7 +3,6 @@ package org.openstack4j.openstack.identity.internal;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
-import java.util.Optional;
 import java.util.SortedSet;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -139,7 +138,7 @@ public class DefaultEndpointURLResolver implements EndpointURLResolver {
 
                 for (org.openstack4j.model.identity.v3.Endpoint ep : service.getEndpoints()) {
 
-                    if (matches(ep, p) && (ep.getUrl().getScheme().matches("^https?$")))
+                    if (matches(ep, p))
                         return ep.getUrl().toString();
                 }
             }

--- a/core/src/main/java/org/openstack4j/openstack/identity/v3/domain/KeystoneEndpoint.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/v3/domain/KeystoneEndpoint.java
@@ -1,5 +1,6 @@
 package org.openstack4j.openstack.identity.v3.domain;
 
+import java.net.URI;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
@@ -36,7 +37,7 @@ public class KeystoneEndpoint implements Endpoint {
     @JsonProperty("region_id")
     private String regionId;
     @JsonProperty
-    private URL url;
+    private URI url;
     private Map<String, String> links;
     private Boolean enabled = true;
 
@@ -123,7 +124,7 @@ public class KeystoneEndpoint implements Endpoint {
      * @return {@inheritDoc}
      */
     @Override
-    public URL getUrl() {
+    public URI getUrl() {
         return url;
     }
 
@@ -302,7 +303,7 @@ public class KeystoneEndpoint implements Endpoint {
          * @see KeystoneEndpoint#getUrl()
          */
         @Override
-        public EndpointBuilder url(URL url) {
+        public EndpointBuilder url(URI url) {
             model.url = url;
             return this;
         }

--- a/core/src/main/java/org/openstack4j/openstack/identity/v3/domain/KeystoneEndpoint.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/v3/domain/KeystoneEndpoint.java
@@ -1,7 +1,6 @@
 package org.openstack4j.openstack.identity.v3.domain;
 
 import java.net.URI;
-import java.net.URL;
 import java.util.List;
 import java.util.Map;
 

--- a/core/src/main/java/org/openstack4j/openstack/identity/v3/internal/ServiceEndpointServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/v3/internal/ServiceEndpointServiceImpl.java
@@ -1,7 +1,6 @@
 package org.openstack4j.openstack.identity.v3.internal;
 
 import java.net.URI;
-import java.net.URL;
 import java.util.List;
 import java.util.Objects;
 

--- a/core/src/main/java/org/openstack4j/openstack/identity/v3/internal/ServiceEndpointServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/v3/internal/ServiceEndpointServiceImpl.java
@@ -1,5 +1,6 @@
 package org.openstack4j.openstack.identity.v3.internal;
 
+import java.net.URI;
 import java.net.URL;
 import java.util.List;
 import java.util.Objects;
@@ -72,7 +73,7 @@ public class ServiceEndpointServiceImpl extends BaseIdentityServices implements 
     }
 
     @Override
-    public Endpoint createEndpoint(String name, URL url, Facing iface, String regionId, String serviceId, boolean enabled) {
+    public Endpoint createEndpoint(String name, URI url, Facing iface, String regionId, String serviceId, boolean enabled) {
         Objects.requireNonNull(name);
         Objects.requireNonNull(url);
         Objects.requireNonNull(iface);


### PR DESCRIPTION
# PR description

I ran into a problem when using Openstack4j via Jenkins openstack-cloud-plugin.
My OpenStack provider has some services with non-HTTP endpoints (wss://, notably) registered in the catalog, so openstack4j fails to deserialize such endpoints when deserializing it.

The only way to mitigate this issue is to migrate from the URL to URI.

I performed such a change and tested the result when using the openstack-cloud-plugin - everything is working fine.

However, it changes the contract a little - if it is critical, I can add some overloads to maintain backward compatibility.
