### PR TITLE
Fix #215 Neutron: Add subnetId to NetFloatingIP

### DIFF
--- a/core-test/src/main/java/org/openstack4j/api/network/NetFloatingIPServiceTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/network/NetFloatingIPServiceTests.java
@@ -46,6 +46,17 @@ public class NetFloatingIPServiceTests extends AbstractTest {
         return Service.NETWORK;
     }
 
+    @Test
+    public void create() throws Exception {
+        respondWithCodeAndResource(201, "/network/network_fips_create.json");
+
+        NetFloatingIP fip = Builders.netFloatingIP().subnetId("9cf3a56a-0f93-4ca7-be18-6979a65f86cb").floatingNetworkId("1188f271-f3ab-491a-a998-7d7fc9e65e01").build();
+        NetFloatingIP created = osv3().networking().floatingip().create(fip);
+        assertEquals(created.getFloatingIpAddress(), "10.19.15.12");
+        assertEquals(created.getProjectId(), "2f0b5d3387f034dfb042c00c007afb4c");
+        assertEquals(created.getFloatingNetworkId(), "1188f271-f3ab-491a-a998-7d7fc9e65e01");
+    }
+
     public void testCreateFailure() throws Exception {
         respondWithCodeAndResource(404, "/network/network_fips_create_fail.json");
 

--- a/core-test/src/main/resources/network/network_fips_create.json
+++ b/core-test/src/main/resources/network/network_fips_create.json
@@ -1,0 +1,20 @@
+{
+    "floatingip": {
+        "status": "DOWN",
+        "description": "",
+        "tags": [],
+        "id": "dccdeb31-6654-4b55-bc0e-007776d7731e",
+        "router_id": null,
+        "tenant_id": "2f0b5d3387f034dfb042c00c007afb4c",
+        "project_id": "2f0b5d3387f034dfb042c00c007afb4c",
+        "floating_network_id": "1188f271-f3ab-491a-a998-7d7fc9e65e01",
+        "subnet_id": null,
+        "floating_ip_address": "10.19.15.12",
+        "fixed_ip_address": null,
+        "port_id": null,
+        "qos_policy_id": null,
+        "created_at": 1687168124000,
+        "updated_at": 1687168124000,
+        "revision_number": 0
+    }
+}

--- a/core/src/main/java/org/openstack4j/model/network/NetFloatingIP.java
+++ b/core/src/main/java/org/openstack4j/model/network/NetFloatingIP.java
@@ -104,4 +104,11 @@ public interface NetFloatingIP extends ModelEntity, Buildable<NetFloatingIPBuild
      * Revision number of a resource.
      */
     Integer getRevisionNumber();
+
+    /**
+     * Subnet id of the IP.
+     *
+     * @return the subnet id
+    */
+    String getSubnetId();
 }

--- a/core/src/main/java/org/openstack4j/model/network/builder/NetFloatingIPBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/network/builder/NetFloatingIPBuilder.java
@@ -42,4 +42,12 @@ public interface NetFloatingIPBuilder extends Builder<NetFloatingIPBuilder, NetF
      * @param description Maximum of 250 characters.
      */
     NetFloatingIPBuilder description(String description);
+
+    /**
+     * sets Id of subnet
+     *
+     * @param subnetId the subnet id
+     * @return the floating ip builder
+     */
+    NetFloatingIPBuilder subnetId(String subnetId);
 }

--- a/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronFloatingIP.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronFloatingIP.java
@@ -63,6 +63,9 @@ public class NeutronFloatingIP implements NetFloatingIP {
     @JsonProperty("revision_number")
     private Integer revisionNumber;
 
+    @JsonProperty("subnet_id")
+    private String subnetId;
+
     /**
      * Builder.
      *
@@ -239,11 +242,26 @@ public class NeutronFloatingIP implements NetFloatingIP {
      * {@inheritDoc}
      */
     @Override
+    public String getSubnetId() {
+        return subnetId;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void setSubnetId(String subnetId) {
+        this.subnetId = subnetId;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public String toString() {
         // Report tenantId iff it differs from projectId
         String distinctTenantId = Objects.equals(tenantId, projectId) ? null: tenantId;
         return new ToStringHelper(this)
-                .add("id", id).add("routerId", routerId).add("floatingNetworkId", floatingNetworkId)
+                .add("id", id).add("routerId", routerId).add("floatingNetworkId", floatingNetworkId).add("subnetId", subnetId)
                 .add("projectId", projectId).add("tenantId", distinctTenantId)
                 .add("floatingIpAddress", floatingIpAddress).add("fixedIpAddress", fixedIpAddress).add("portId", portId).add("status", status)
                 .toString();
@@ -253,7 +271,7 @@ public class NeutronFloatingIP implements NetFloatingIP {
     public int hashCode() {
         return Objects.hash(
                 id, routerId, tenantId, projectId, floatingNetworkId, floatingIpAddress, fixedIpAddress, portId,
-                qosPolicyId, status, description, tags, createdAt, updatedAt, revisionNumber
+                qosPolicyId, status, description, tags, createdAt, updatedAt, revisionNumber, subnetId
         );
     }
 
@@ -276,7 +294,8 @@ public class NeutronFloatingIP implements NetFloatingIP {
                 Objects.equals(tags, that.tags) &&
                 Objects.equals(createdAt, that.createdAt) &&
                 Objects.equals(updatedAt, that.updatedAt) &&
-                Objects.equals(revisionNumber, that.revisionNumber);
+                Objects.equals(revisionNumber, that.revisionNumber) &&
+                Objects.equals(subnetId, that.subnetId);
     }
 
     /**
@@ -375,6 +394,12 @@ public class NeutronFloatingIP implements NetFloatingIP {
         @Override
         public NetFloatingIPBuilder description(String description) {
             f.description = description;
+            return this;
+        }
+
+        @Override
+        public NetFloatingIPBuilder subnetId(String subnetId) {
+            f.subnetId = subnetId;
             return this;
         }
     }


### PR DESCRIPTION
# PR description

Add subnetId field to NetFloatingIp. This field is used when creating a FloatingIp, to ensure it goes to a specific subnet.
https://docs.openstack.org/api-ref/network/v2/index.html?expanded=#create-floating-ip

## Submitter checklist

Make sure that following is addressed to make the PR easier to process:

- [x] If applicable, changes are covered by either a unit or a functional test.
- [x] If applicable, changes ware verified manually against an OpenStack instance.
- [x] If the change is API related, the PR description links to OpenStack API documentation of that particular endpoint/request (https://docs.openstack.org/api-quick-start/#current-api-versions).
- [x] If the change concerns particular OpenStack service, its name is used as a PR name prefix (ex.: "Neutron: Add floatingIp port forwardings service").
- [x] If the PR closes existing GitHub issue, PR name have prefix: `Fix #NNN: `.
