### PR TITLE
Neutron:list port support fields to query

### DIFF
--- a/core/src/main/java/org/openstack4j/api/networking/PortService.java
+++ b/core/src/main/java/org/openstack4j/api/networking/PortService.java
@@ -1,6 +1,7 @@
 package org.openstack4j.api.networking;
 
 import java.util.List;
+import java.util.Map;
 
 import org.openstack4j.common.RestService;
 import org.openstack4j.model.common.ActionResponse;
@@ -28,6 +29,15 @@ public interface PortService extends RestService {
      * @return the list of ports
      */
     List<? extends Port> list(PortListOptions options);
+
+    /**
+     * Lists all Ports authorized by the current Tenant
+     * <br/>
+     * Supports multiple values, eg: fields=id&fields=name
+     * @param params filtering options
+     * @return the list of ports
+     */
+    List<? extends Port> list(Map<String, ? extends Iterable<?>> params);
 
     /**
      * Gets the Port by ID

--- a/core/src/main/java/org/openstack4j/openstack/networking/internal/PortServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/internal/PortServiceImpl.java
@@ -1,6 +1,7 @@
 package org.openstack4j.openstack.networking.internal;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import org.openstack4j.api.networking.PortService;
@@ -32,6 +33,14 @@ public class PortServiceImpl extends BaseNetworkingServices implements PortServi
             return list();
 
         return get(Ports.class, uri("/ports")).params(options.getOptions()).execute().getList();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<? extends Port> list(Map<String, ? extends Iterable<?>> params) {
+        return get(Ports.class, uri("/ports")).paramLists(params).execute().getList();
     }
 
     /**


### PR DESCRIPTION
# PR description

This PR provides an optional API to query port using multiple values with one key.

eg:
fields=id&fields=name

API:
Neutron GET /v2.0/ports

>Use the fields query parameter to control which fields are returned in the response body. Additionally, you can filter results by using query string parameters. 