### PR TITLE
Nova: create server with 'volume_type', 'hypervisor_hostname', 'avail…

### DIFF
--- a/core/src/main/java/org/openstack4j/model/compute/ServerCreate.java
+++ b/core/src/main/java/org/openstack4j/model/compute/ServerCreate.java
@@ -120,6 +120,10 @@ public interface ServerCreate extends ModelEntity, Buildable<ServerCreateBuilder
      */
     String getAvailabilityZone();
 
+    String getHost();
+
+    String getHypervisorHostName();
+
     /**
      * Gets the networks.
      *

--- a/core/src/main/java/org/openstack4j/model/compute/builder/BlockDeviceMappingBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/compute/builder/BlockDeviceMappingBuilder.java
@@ -99,4 +99,11 @@ public interface BlockDeviceMappingBuilder extends Buildable.Builder<BlockDevice
      * @return BlockDeviceMappingBuilder
      */
     BlockDeviceMappingBuilder deviceType(String deviceType);
+
+    /**
+     * This can be used to specify the type of volume which the compute service will create and attach to the server.
+     * @param volumeType The device volume_type.
+     * @return BlockDeviceMappingBuilder
+     */
+    BlockDeviceMappingBuilder volumeType(String volumeType);
 }

--- a/core/src/main/java/org/openstack4j/model/compute/builder/ServerCreateBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/compute/builder/ServerCreateBuilder.java
@@ -134,6 +134,20 @@ public interface ServerCreateBuilder extends Buildable.Builder<ServerCreateBuild
     ServerCreateBuilder availabilityZone(String availabilityZone);
 
     /**
+     * The name of the compute service host on which the server is to be created.
+     * @param host The name of the compute service host
+     * @return this builder
+     */
+    ServerCreateBuilder host(String host);
+
+    /**
+     * The hostname of the hypervisor on which the server is to be created.
+     * @param hypervisorHostName The hostname of the hypervisor
+     * @return this builder
+     */
+    ServerCreateBuilder hypervisorHostName(String hypervisorHostName);
+
+    /**
      * Cloud-init userdata
      *
      * @param userData a base64 encoded string containing the userdata
@@ -144,7 +158,7 @@ public interface ServerCreateBuilder extends Buildable.Builder<ServerCreateBuild
     /**
      * Add admin password for launching the server.
      *
-     * @param password the password
+     * @param adminPass the password
      * @return this builder
      */
 

--- a/core/src/main/java/org/openstack4j/openstack/compute/domain/NovaBlockDeviceMappingCreate.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/domain/NovaBlockDeviceMappingCreate.java
@@ -35,6 +35,9 @@ public class NovaBlockDeviceMappingCreate implements BlockDeviceMappingCreate {
     @JsonProperty("device_type")
     public String deviceType;
 
+    @JsonProperty("volume_type")
+    public String volumeType;
+
     public static NovaBlockDeviceMappingBuilder builder() {
         return new NovaBlockDeviceMappingBuilder(new NovaBlockDeviceMappingCreate());
     }
@@ -116,6 +119,12 @@ public class NovaBlockDeviceMappingCreate implements BlockDeviceMappingCreate {
         @Override
         public BlockDeviceMappingBuilder deviceType(String deviceType) {
             create.deviceType = deviceType;
+            return this;
+        }
+
+        @Override
+        public BlockDeviceMappingBuilder volumeType(String volumeType) {
+            create.volumeType = volumeType;
             return this;
         }
 

--- a/core/src/main/java/org/openstack4j/openstack/compute/domain/NovaServerCreate.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/domain/NovaServerCreate.java
@@ -32,6 +32,9 @@ public class NovaServerCreate implements ServerCreate {
     private String keyName;
     @JsonProperty("availability_zone")
     private String availabilityZone;
+    private String host;
+    @JsonProperty("hypervisor_hostname")
+    private String hypervisorHostName;
     @JsonProperty("config_drive")
     private Boolean configDrive;
 
@@ -127,6 +130,16 @@ public class NovaServerCreate implements ServerCreate {
     @Override
     public String getAvailabilityZone() {
         return availabilityZone;
+    }
+
+    @Override
+    public String getHost() {
+        return host;
+    }
+
+    @Override
+    public String getHypervisorHostName() {
+        return hypervisorHostName;
     }
 
     @JsonIgnore
@@ -292,6 +305,18 @@ public class NovaServerCreate implements ServerCreate {
         @Override
         public ServerCreateBuilder availabilityZone(String availabilityZone) {
             m.availabilityZone = availabilityZone;
+            return this;
+        }
+
+        @Override
+        public ServerCreateBuilder host(String host) {
+            m.host = host;
+            return this;
+        }
+
+        @Override
+        public ServerCreateBuilder hypervisorHostName(String hypervisorHostName) {
+            m.hypervisorHostName = hypervisorHostName;
             return this;
         }
 


### PR DESCRIPTION
# PR description

**create server changes**

add several fields for creating server:
* availability_zone (Optional) 
* hypervisor_hostname **since 2.74**
* block_device_mapping_v2.volume_type (Optional)  **since 2.67**

Those fields are important for IaaS system to improve High Availability and multiple cinder backend support.

REF: [Openstack Docs | create-server-detail](https://docs.openstack.org/api-ref/compute/?expanded=create-server-detail#create-server)
