### PR TITLE
Neutron：add qos_policy_id for NeutronPort and id for PortBuilder when…

### DIFF
--- a/core/src/main/java/org/openstack4j/model/network/Port.java
+++ b/core/src/main/java/org/openstack4j/model/network/Port.java
@@ -87,4 +87,6 @@ public interface Port extends Resource, TimeEntity, Buildable<PortBuilder> {
     String getvNicType();
 
     Map<String, Object> getProfile();
+
+    String getQosPolicyId();
 }

--- a/core/src/main/java/org/openstack4j/model/network/builder/PortBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/network/builder/PortBuilder.java
@@ -16,6 +16,11 @@ import org.openstack4j.model.network.State;
 public interface PortBuilder extends Builder<PortBuilder, Port> {
 
     /**
+     * @see Port#getId()
+     */
+    PortBuilder id(String id);
+
+    /**
      * @see Port#getName()
      */
     PortBuilder name(String name);
@@ -128,6 +133,8 @@ public interface PortBuilder extends Builder<PortBuilder, Port> {
     PortBuilder securityGroup(String groupName);
 
     PortBuilder portSecurityEnabled(Boolean portSecurityEnabled);
+
+    PortBuilder qosPolicyId(String qosPolicyId);
 
     PortBuilder hostId(String hostId);
 

--- a/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronPort.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronPort.java
@@ -70,6 +70,9 @@ public class NeutronPort implements Port {
     @JsonProperty("port_security_enabled")
     private Boolean portSecurityEnabled;
 
+    @JsonProperty("qos_policy_id")
+    private String qosPolicyId;
+
     @JsonProperty("binding:host_id")
     private String hostId;
 
@@ -280,6 +283,15 @@ public class NeutronPort implements Port {
         this.profile = profile;
     }
 
+    @Override
+    public String getQosPolicyId() {
+        return qosPolicyId;
+    }
+
+    public void setQosPolicyId(String qosPolicyId) {
+        this.qosPolicyId = qosPolicyId;
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -334,6 +346,7 @@ public class NeutronPort implements Port {
                 .add("deviceOwner", deviceOwner).add("fixedIps", fixedIps).add("macAddress", macAddress)
                 .add("networkId", networkId).add("tenantId", tenantId).add("securityGroups", securityGroups)
                 .add("allowed_address_pairs", allowedAddressPairs).add("port_security_enabled ", portSecurityEnabled)
+                .add("qos_policy_id ", qosPolicyId)
                 .add("binding:host_id", hostId).add("binding:vif_type", vifType).add("binding:vif_details", vifDetails)
                 .add("binding:vnic_type", vNicType).add("binding:profile", profile)
                 .add("created_at", createdTime).add("updated_at", updatedTime)
@@ -347,7 +360,7 @@ public class NeutronPort implements Port {
     public int hashCode() {
         return java.util.Objects.hash(id, name, adminStateUp, deviceId,
                 deviceOwner, fixedIps, macAddress, networkId, tenantId,
-                securityGroups, allowedAddressPairs, portSecurityEnabled, hostId,
+                securityGroups, allowedAddressPairs, portSecurityEnabled, qosPolicyId, hostId,
                 vifType, vifDetails, vNicType, profile, createdTime, updatedTime);
     }
 
@@ -374,6 +387,7 @@ public class NeutronPort implements Port {
                     java.util.Objects.equals(securityGroups, that.securityGroups) &&
                     java.util.Objects.equals(allowedAddressPairs, that.allowedAddressPairs) &&
                     java.util.Objects.equals(portSecurityEnabled, that.portSecurityEnabled) &&
+                    java.util.Objects.equals(qosPolicyId, that.qosPolicyId) &&
                     java.util.Objects.equals(hostId, that.hostId) &&
                     java.util.Objects.equals(vifType, that.vifType) &&
                     java.util.Objects.equals(vifDetails, that.vifDetails) &&
@@ -545,6 +559,12 @@ public class NeutronPort implements Port {
         @Override
         public PortBuilder portSecurityEnabled(Boolean portSecurityEnabled) {
             m.portSecurityEnabled = portSecurityEnabled;
+            return this;
+        }
+
+        @Override
+        public PortBuilder qosPolicyId(String qosPolicyId) {
+            m.qosPolicyId = qosPolicyId;
             return this;
         }
 

--- a/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronPortCreate.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronPortCreate.java
@@ -70,6 +70,9 @@ public class NeutronPortCreate implements ModelEntity {
     @JsonProperty("binding:profile")
     private Map<String, Object> profile;
 
+    @JsonProperty("qos_policy_id")
+    private String qosPolicyId;
+
 
     public NeutronPortCreate() {
     }
@@ -99,7 +102,7 @@ public class NeutronPortCreate implements ModelEntity {
         c.vifDetails = port.getVifDetails();
         c.vNicType = port.getvNicType();
         c.profile = port.getProfile();
-
+        c.qosPolicyId = port.getQosPolicyId();
 
         return c;
     }


### PR DESCRIPTION
# PR description

Neutron Changes:

* add 'qos_policy_id' for NeutronPort
* add id for PortBuilder: useful when updating port.

REF: [Openstack Docs | Neworking V2 | Ports](https://docs.openstack.org/api-ref/network/v2/index.html#ports)