### PR TITLE
Fix #111 Neutron: bandwidth limit rule

### DIFF
--- a/core-test/src/main/java/org/openstack4j/api/network/NetQosBandwidthLimitRuleTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/network/NetQosBandwidthLimitRuleTests.java
@@ -16,6 +16,7 @@ import static org.testng.Assert.assertTrue;
  * Test cases for (Neutron) qos policy bandwidth limit rule extension based Services
  *
  * @author bboyHan
+ * @author slankka
  */
 @Test(suiteName = "Network/qosPolicyBandwidthLimitRule")
 public class NetQosBandwidthLimitRuleTests extends AbstractTest {
@@ -25,30 +26,32 @@ public class NetQosBandwidthLimitRuleTests extends AbstractTest {
 
     public void list() throws IOException {
         respondWith(QOS_POLICY_BANDWIDTH_LIMIT_RULES_JSON);
-        List<? extends NetQosPolicyBandwidthLimitRule> qosPolicyBandwidthLimitRules = osv3().networking().netQosPolicyBandWidthLimitRule().list("policyId");
+        List<? extends NetQosPolicyBandwidthLimitRule> qosPolicyBandwidthLimitRules = osv3().networking().netQosPolicyBandwidthLimitRule().list("policyId");
         assertEquals(1, qosPolicyBandwidthLimitRules.size());
         assertEquals(10000, (int)qosPolicyBandwidthLimitRules.get(0).getMaxKbps());
     }
 
     public void get() throws IOException {
         respondWith(QOS_POLICY_BANDWIDTH_LIMIT_RULE_JSON);
-        NetQosPolicyBandwidthLimitRule netQosPolicyBandwidthLimitRule = osv3().networking().netQosPolicyBandWidthLimitRule().get("networkId", "ruleId");
+        NetQosPolicyBandwidthLimitRule netQosPolicyBandwidthLimitRule = osv3().networking().netQosPolicyBandwidthLimitRule().get("networkId", "ruleId");
         assertEquals("5f126d84-551a-4dcf-bb01-0e9c0df0c793", netQosPolicyBandwidthLimitRule.getId());
-        assertEquals("egress", netQosPolicyBandwidthLimitRule.getDirection());
+        assertEquals("egress", netQosPolicyBandwidthLimitRule.getDirectionValue());
+        assertEquals(NetQosPolicyBandwidthLimitRule.Direction.egress, netQosPolicyBandwidthLimitRule.getDirection());
     }
 
     public void delete() {
         respondWith(204);
-        ActionResponse response = osv3().networking().netQosPolicyBandWidthLimitRule().delete("policyId", "ruleId");
+        ActionResponse response = osv3().networking().netQosPolicyBandwidthLimitRule().delete("policyId", "ruleId");
         assertTrue(response.isSuccess());
     }
 
     public void create() throws IOException {
         respondWith(QOS_POLICY_BANDWIDTH_LIMIT_RULE_JSON);
-        NetQosPolicyBandwidthLimitRule netQosPolicyBandwidthLimitRule = osv3().networking().netQosPolicyBandWidthLimitRule()
+        NetQosPolicyBandwidthLimitRule netQosPolicyBandwidthLimitRule = osv3().networking().netQosPolicyBandwidthLimitRule()
                 .create("policyId", NeutronNetQosPolicyBandwidthLimitRule.builder().maxKbps(10000).build());
         assertEquals("5f126d84-551a-4dcf-bb01-0e9c0df0c793", netQosPolicyBandwidthLimitRule.getId());
-        assertEquals("egress", netQosPolicyBandwidthLimitRule.getDirection());
+        assertEquals("egress", netQosPolicyBandwidthLimitRule.getDirectionValue());
+        assertEquals(NetQosPolicyBandwidthLimitRule.Direction.egress, netQosPolicyBandwidthLimitRule.getDirection());
     }
 
     @Override

--- a/core-test/src/main/java/org/openstack4j/api/network/NetQosBandwidthLimitRuleTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/network/NetQosBandwidthLimitRuleTests.java
@@ -1,0 +1,58 @@
+package org.openstack4j.api.network;
+
+import org.openstack4j.api.AbstractTest;
+import org.openstack4j.model.common.ActionResponse;
+import org.openstack4j.model.network.ext.NetQosPolicyBandwidthLimitRule;
+import org.openstack4j.openstack.networking.domain.ext.NeutronNetQosPolicyBandwidthLimitRule;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Test cases for (Neutron) qos policy bandwidth limit rule extension based Services
+ *
+ * @author bboyHan
+ */
+@Test(suiteName = "Network/qosPolicyBandwidthLimitRule")
+public class NetQosBandwidthLimitRuleTests extends AbstractTest {
+
+    private static final String QOS_POLICY_BANDWIDTH_LIMIT_RULE_JSON = "/network/qos_bandwidth_limit_rule.json";
+    private static final String QOS_POLICY_BANDWIDTH_LIMIT_RULES_JSON = "/network/qos_bandwidth_limit_rules.json";
+
+    public void list() throws IOException {
+        respondWith(QOS_POLICY_BANDWIDTH_LIMIT_RULES_JSON);
+        List<? extends NetQosPolicyBandwidthLimitRule> qosPolicyBandwidthLimitRules = osv3().networking().netQosPolicyBandWidthLimitRule().list("policyId");
+        assertEquals(1, qosPolicyBandwidthLimitRules.size());
+        assertEquals(10000, (int)qosPolicyBandwidthLimitRules.get(0).getMaxKbps());
+    }
+
+    public void get() throws IOException {
+        respondWith(QOS_POLICY_BANDWIDTH_LIMIT_RULE_JSON);
+        NetQosPolicyBandwidthLimitRule netQosPolicyBandwidthLimitRule = osv3().networking().netQosPolicyBandWidthLimitRule().get("networkId", "ruleId");
+        assertEquals("5f126d84-551a-4dcf-bb01-0e9c0df0c793", netQosPolicyBandwidthLimitRule.getId());
+        assertEquals("egress", netQosPolicyBandwidthLimitRule.getDirection());
+    }
+
+    public void delete() {
+        respondWith(204);
+        ActionResponse response = osv3().networking().netQosPolicyBandWidthLimitRule().delete("policyId", "ruleId");
+        assertTrue(response.isSuccess());
+    }
+
+    public void create() throws IOException {
+        respondWith(QOS_POLICY_BANDWIDTH_LIMIT_RULE_JSON);
+        NetQosPolicyBandwidthLimitRule netQosPolicyBandwidthLimitRule = osv3().networking().netQosPolicyBandWidthLimitRule()
+                .create("policyId", NeutronNetQosPolicyBandwidthLimitRule.builder().maxKbps(10000).build());
+        assertEquals("5f126d84-551a-4dcf-bb01-0e9c0df0c793", netQosPolicyBandwidthLimitRule.getId());
+        assertEquals("egress", netQosPolicyBandwidthLimitRule.getDirection());
+    }
+
+    @Override
+    protected Service service() {
+        return Service.NETWORK;
+    }
+}

--- a/core-test/src/main/resources/network/qos_bandwidth_limit_rule.json
+++ b/core-test/src/main/resources/network/qos_bandwidth_limit_rule.json
@@ -1,0 +1,8 @@
+{
+  "bandwidth_limit_rule": {
+    "id": "5f126d84-551a-4dcf-bb01-0e9c0df0c793",
+    "max_kbps": 10000,
+    "max_burst_kbps": 0,
+    "direction": "egress"
+  }
+}

--- a/core-test/src/main/resources/network/qos_bandwidth_limit_rules.json
+++ b/core-test/src/main/resources/network/qos_bandwidth_limit_rules.json
@@ -1,0 +1,10 @@
+{
+  "bandwidth_limit_rules": [
+    {
+      "id": "5f126d84-551a-4dcf-bb01-0e9c0df0c793",
+      "max_kbps": 10000,
+      "max_burst_kbps": 0,
+      "direction": "egress"
+    }
+  ]
+}

--- a/core/src/main/java/org/openstack4j/api/networking/NetworkingService.java
+++ b/core/src/main/java/org/openstack4j/api/networking/NetworkingService.java
@@ -96,4 +96,10 @@ public interface NetworkingService extends RestService {
      * @return the Networking (Neutron) Qos Policy Extension API
      */
     NetQosPolicyService netQosPolicy();
+
+    /**
+     * @return the Networking (Neutron) Qos Policy Bandwidth Limit Rule Extension API
+     */
+    NetQosPolicyBLRuleService netQosPolicyBandWidthLimitRule();
+
 }

--- a/core/src/main/java/org/openstack4j/api/networking/NetworkingService.java
+++ b/core/src/main/java/org/openstack4j/api/networking/NetworkingService.java
@@ -100,6 +100,6 @@ public interface NetworkingService extends RestService {
     /**
      * @return the Networking (Neutron) Qos Policy Bandwidth Limit Rule Extension API
      */
-    NetQosPolicyBLRuleService netQosPolicyBandWidthLimitRule();
+    NetQosPolicyBLRuleService netQosPolicyBandwidthLimitRule();
 
 }

--- a/core/src/main/java/org/openstack4j/api/networking/ext/NetQosPolicyBLRuleService.java
+++ b/core/src/main/java/org/openstack4j/api/networking/ext/NetQosPolicyBLRuleService.java
@@ -1,0 +1,57 @@
+package org.openstack4j.api.networking.ext;
+
+import org.openstack4j.common.RestService;
+import org.openstack4j.model.common.ActionResponse;
+import org.openstack4j.model.network.ext.NetQosPolicyBandwidthLimitRule;
+
+import java.util.List;
+
+/**
+ * Networking (Neutron) Qos Policy Bandwidth Limit Rule Extension API
+ *
+ * @author bboyHan
+ */
+public interface NetQosPolicyBLRuleService extends RestService {
+
+    /**
+     * Lists qos policy bandwidth-limit-rules for tenants
+     *
+     * @param policyId policy id
+     * @return the list of qos policy bandwidth limit rules
+     */
+    List<? extends NetQosPolicyBandwidthLimitRule> list(String policyId);
+
+    /**
+     * Fetches the network qos policy bandwidth-limit-rule for the specified tenant
+     *
+     * @param policyId policy id
+     * @return NetQosPolicyBandwidthLimitRule
+     */
+    NetQosPolicyBandwidthLimitRule get(String policyId, String ruleId);
+
+    /**
+     * Updates the network qos policy bandwidth limit rule for the current tenant
+     *
+     * @param policyId policy id
+     * @param bandwidthLimitRule the net qos policy bandwidth limit rule to update
+     * @return NetQosPolicyBandwidthLimitRule
+     */
+    NetQosPolicyBandwidthLimitRule update(String policyId, NetQosPolicyBandwidthLimitRule bandwidthLimitRule);
+
+    /**
+     * Create the current network qos policy bandwidth limit rule for the current tenant back to defaults
+     *
+     * @param policyId policy id
+     * @return NetQosPolicyBandwidthLimitRule the response object
+     */
+    NetQosPolicyBandwidthLimitRule create(String policyId, NetQosPolicyBandwidthLimitRule bandwidthLimitRule);
+
+    /**
+     * Delete the current network qos policy bandwidth limit rule for the current tenant back to defaults
+     *
+     * @param policyId policy id
+     * @param ruleId the net qos policy bandwidth limit rule uuid
+     * @return the action response
+     */
+    ActionResponse delete(String policyId, String ruleId);
+}

--- a/core/src/main/java/org/openstack4j/model/network/ext/NetQosPolicyBandwidthLimitRule.java
+++ b/core/src/main/java/org/openstack4j/model/network/ext/NetQosPolicyBandwidthLimitRule.java
@@ -1,14 +1,19 @@
 package org.openstack4j.model.network.ext;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import org.openstack4j.common.Buildable;
 import org.openstack4j.model.common.IdEntity;
 import org.openstack4j.model.network.ext.builder.NetQosPolicyBandwidthLimitRuleBuilder;
 import org.openstack4j.openstack.networking.domain.ext.NeutronNetQosPolicyRuleTag;
 
+import javax.annotation.Nullable;
+import java.util.Objects;
+
 /**
  * Network qos policy band-width-limit that are bound to a Tenant
  *
  * @author bboyHan
+ * @author slankka
  */
 public interface NetQosPolicyBandwidthLimitRule extends IdEntity, Buildable<NetQosPolicyBandwidthLimitRuleBuilder> {
 
@@ -33,7 +38,9 @@ public interface NetQosPolicyBandwidthLimitRule extends IdEntity, Buildable<NetQ
      *
      * @return direction
      */
-    String getDirection();
+    Direction getDirection();
+
+    String getDirectionValue();
 
     /**
      * The list of tags on the resource.
@@ -41,5 +48,24 @@ public interface NetQosPolicyBandwidthLimitRule extends IdEntity, Buildable<NetQ
      * @return tags
      */
     NeutronNetQosPolicyRuleTag getTags();
+
+
+    enum Direction {
+        ingress,
+        egress;
+
+        /**
+         * @see <a href="https://www.baeldung.com/jackson-serialize-enums">jackson-serialize-enums</a>
+         * @param direction nullable direction
+         * @return Direction
+         */
+        @JsonCreator
+        public static Direction forValues(@Nullable String direction) {
+            if (Objects.isNull(direction) || Objects.equals(direction, "")) {
+                return null;
+            }
+            return Direction.valueOf(direction);
+        }
+    }
 
 }

--- a/core/src/main/java/org/openstack4j/model/network/ext/NetQosPolicyBandwidthLimitRule.java
+++ b/core/src/main/java/org/openstack4j/model/network/ext/NetQosPolicyBandwidthLimitRule.java
@@ -1,0 +1,45 @@
+package org.openstack4j.model.network.ext;
+
+import org.openstack4j.common.Buildable;
+import org.openstack4j.model.common.IdEntity;
+import org.openstack4j.model.network.ext.builder.NetQosPolicyBandwidthLimitRuleBuilder;
+import org.openstack4j.openstack.networking.domain.ext.NeutronNetQosPolicyRuleTag;
+
+/**
+ * Network qos policy band-width-limit that are bound to a Tenant
+ *
+ * @author bboyHan
+ */
+public interface NetQosPolicyBandwidthLimitRule extends IdEntity, Buildable<NetQosPolicyBandwidthLimitRuleBuilder> {
+
+    /**
+     * The maximum KBPS (kilobits per second) value.
+     * If you specify this value, must be greater than 0 otherwise max_kbps will have no value.
+     *
+     * @return maxKbps
+     */
+    Integer getMaxKbps();
+
+    /**
+     * The maximum burst size (in kilobits).
+     *
+     * @return maxBurstKbps
+     */
+    Integer getMaxBurstKbps();
+
+    /**
+     * The direction of the traffic to which the QoS rule is applied, as seen from the point of view of the port.
+     * Valid values are egress and ingress. Default value is egress.
+     *
+     * @return direction
+     */
+    String getDirection();
+
+    /**
+     * The list of tags on the resource.
+     *
+     * @return tags
+     */
+    NeutronNetQosPolicyRuleTag getTags();
+
+}

--- a/core/src/main/java/org/openstack4j/model/network/ext/builder/NetQosPolicyBandwidthLimitRuleBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/network/ext/builder/NetQosPolicyBandwidthLimitRuleBuilder.java
@@ -1,0 +1,37 @@
+package org.openstack4j.model.network.ext.builder;
+
+import org.openstack4j.common.Buildable.Builder;
+import org.openstack4j.model.network.ext.NetQosPolicyBandwidthLimitRule;
+
+/**
+ * A Builder which creates a NetQosPolicyBandwidthLimitRule entity
+ *
+ * @author bboyHan
+ */
+public interface NetQosPolicyBandwidthLimitRuleBuilder extends Builder<NetQosPolicyBandwidthLimitRuleBuilder, NetQosPolicyBandwidthLimitRule> {
+
+    /**
+     * See {@link NetQosPolicyBandwidthLimitRule#getMaxKbps()} for details
+     *
+     * @param maxKbps maxKbps
+     * @return NetQosPolicyBandwidthLimitRuleBuilder
+     */
+    NetQosPolicyBandwidthLimitRuleBuilder maxKbps(Integer maxKbps);
+
+    /**
+     * See {@link NetQosPolicyBandwidthLimitRule#getMaxBurstKbps()} for details
+     *
+     * @param maxBurstKbps maxBurstKbps
+     * @return NetQosPolicyBandwidthLimitRuleBuilder
+     */
+    NetQosPolicyBandwidthLimitRuleBuilder maxBurstKbps(Integer maxBurstKbps);
+
+    /**
+     * See {@link NetQosPolicyBandwidthLimitRule#getDirection()} for details
+     *
+     * @param direction direction
+     * @return NetQosPolicyBandwidthLimitRuleBuilder
+     */
+    NetQosPolicyBandwidthLimitRuleBuilder direction(String direction);
+
+}

--- a/core/src/main/java/org/openstack4j/model/network/ext/builder/NetQosPolicyBandwidthLimitRuleBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/network/ext/builder/NetQosPolicyBandwidthLimitRuleBuilder.java
@@ -7,6 +7,7 @@ import org.openstack4j.model.network.ext.NetQosPolicyBandwidthLimitRule;
  * A Builder which creates a NetQosPolicyBandwidthLimitRule entity
  *
  * @author bboyHan
+ * @author slankka
  */
 public interface NetQosPolicyBandwidthLimitRuleBuilder extends Builder<NetQosPolicyBandwidthLimitRuleBuilder, NetQosPolicyBandwidthLimitRule> {
 
@@ -32,6 +33,6 @@ public interface NetQosPolicyBandwidthLimitRuleBuilder extends Builder<NetQosPol
      * @param direction direction
      * @return NetQosPolicyBandwidthLimitRuleBuilder
      */
-    NetQosPolicyBandwidthLimitRuleBuilder direction(String direction);
+    NetQosPolicyBandwidthLimitRuleBuilder direction(NetQosPolicyBandwidthLimitRule.Direction direction);
 
 }

--- a/core/src/main/java/org/openstack4j/openstack/networking/domain/ext/NeutronNetQosPolicyBandwidthLimitRule.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/domain/ext/NeutronNetQosPolicyBandwidthLimitRule.java
@@ -1,5 +1,6 @@
 package org.openstack4j.openstack.networking.domain.ext;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 import org.openstack4j.model.network.ext.NetQosPolicyBandwidthLimitRule;
@@ -14,6 +15,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
  * Network qos policy band-width-limit that are bound to a Tenant
  *
  * @author bboyHan
+ * @author slankka
  */
 @JsonRootName("bandwidth_limit_rule")
 public class NeutronNetQosPolicyBandwidthLimitRule implements NetQosPolicyBandwidthLimitRule {
@@ -27,7 +29,7 @@ public class NeutronNetQosPolicyBandwidthLimitRule implements NetQosPolicyBandwi
     @JsonProperty("max_burst_kbps")
     private Integer maxBurstKbps;
     @JsonProperty
-    private String direction;
+    private Direction direction;
     @JsonProperty
     private NeutronNetQosPolicyRuleTag tags;
 
@@ -57,8 +59,14 @@ public class NeutronNetQosPolicyBandwidthLimitRule implements NetQosPolicyBandwi
         return maxBurstKbps;
     }
 
-    public String getDirection() {
+    public Direction getDirection() {
         return direction;
+    }
+
+    @Override
+    @JsonIgnore
+    public String getDirectionValue() {
+        return direction == null ? null: direction.name();
     }
 
     public NeutronNetQosPolicyRuleTag getTags() {
@@ -109,7 +117,7 @@ public class NeutronNetQosPolicyBandwidthLimitRule implements NetQosPolicyBandwi
         }
 
         @Override
-        public NetQosPolicyBandwidthLimitRuleBuilder direction(String direction) {
+        public NetQosPolicyBandwidthLimitRuleBuilder direction(Direction direction) {
             model.direction = direction;
             return this;
         }

--- a/core/src/main/java/org/openstack4j/openstack/networking/domain/ext/NeutronNetQosPolicyBandwidthLimitRule.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/domain/ext/NeutronNetQosPolicyBandwidthLimitRule.java
@@ -1,0 +1,132 @@
+package org.openstack4j.openstack.networking.domain.ext;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+import org.openstack4j.model.network.ext.NetQosPolicyBandwidthLimitRule;
+import org.openstack4j.model.network.ext.builder.NetQosPolicyBandwidthLimitRuleBuilder;
+import org.openstack4j.openstack.common.ListResult;
+
+import java.util.List;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+/**
+ * Network qos policy band-width-limit that are bound to a Tenant
+ *
+ * @author bboyHan
+ */
+@JsonRootName("bandwidth_limit_rule")
+public class NeutronNetQosPolicyBandwidthLimitRule implements NetQosPolicyBandwidthLimitRule {
+
+    private static final long serialVersionUID = 1L;
+
+    @JsonProperty
+    private String id;
+    @JsonProperty("max_kbps")
+    private Integer maxKbps;
+    @JsonProperty("max_burst_kbps")
+    private Integer maxBurstKbps;
+    @JsonProperty
+    private String direction;
+    @JsonProperty
+    private NeutronNetQosPolicyRuleTag tags;
+
+    public static NetQosPolicyBandwidthLimitRuleBuilder builder() {
+        return new NetQosPolicyBandwidthLimitRuleConcreteBuilder();
+    }
+
+    @Override
+    public NetQosPolicyBandwidthLimitRuleBuilder toBuilder() {
+        return new NetQosPolicyBandwidthLimitRuleConcreteBuilder(this);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Integer getMaxKbps() {
+        return maxKbps;
+    }
+
+    public Integer getMaxBurstKbps() {
+        return maxBurstKbps;
+    }
+
+    public String getDirection() {
+        return direction;
+    }
+
+    public NeutronNetQosPolicyRuleTag getTags() {
+        return tags;
+    }
+
+    @Override
+    public String toString() {
+        return toStringHelper(this)
+                .add("id", id).add("maxKbps", maxKbps).add("maxBurstKbps", maxBurstKbps)
+                .add("direction", direction).add("tags", tags)
+                .toString();
+    }
+
+    public static class NetQosPolicyBandwidthLimitRuleConcreteBuilder implements NetQosPolicyBandwidthLimitRuleBuilder {
+
+        private NeutronNetQosPolicyBandwidthLimitRule model;
+
+        public NetQosPolicyBandwidthLimitRuleConcreteBuilder() {
+            model = new NeutronNetQosPolicyBandwidthLimitRule();
+        }
+
+        public NetQosPolicyBandwidthLimitRuleConcreteBuilder(NeutronNetQosPolicyBandwidthLimitRule model) {
+            this.model = model;
+        }
+
+        @Override
+        public NetQosPolicyBandwidthLimitRule build() {
+            return model;
+        }
+
+        @Override
+        public NetQosPolicyBandwidthLimitRuleBuilder from(NetQosPolicyBandwidthLimitRule in) {
+            model = (NeutronNetQosPolicyBandwidthLimitRule) in;
+            return this;
+        }
+
+        @Override
+        public NetQosPolicyBandwidthLimitRuleBuilder maxKbps(Integer maxKbps) {
+            model.maxKbps = maxKbps;
+            return this;
+        }
+
+        @Override
+        public NetQosPolicyBandwidthLimitRuleBuilder maxBurstKbps(Integer maxBurstKbps) {
+            model.maxBurstKbps = maxBurstKbps;
+            return this;
+        }
+
+        @Override
+        public NetQosPolicyBandwidthLimitRuleBuilder direction(String direction) {
+            model.direction = direction;
+            return this;
+        }
+
+    }
+
+    public static class NeutronNetQosPolicyBLRules extends ListResult<NeutronNetQosPolicyBandwidthLimitRule> {
+
+        private static final long serialVersionUID = 1L;
+
+        @JsonProperty("bandwidth_limit_rules")
+        private List<NeutronNetQosPolicyBandwidthLimitRule> bandwidthLimitRules;
+
+        @Override
+        protected List<NeutronNetQosPolicyBandwidthLimitRule> value() {
+            return bandwidthLimitRules;
+        }
+    }
+
+}

--- a/core/src/main/java/org/openstack4j/openstack/networking/domain/ext/NeutronNetQosPolicyRuleTag.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/domain/ext/NeutronNetQosPolicyRuleTag.java
@@ -1,0 +1,38 @@
+package org.openstack4j.openstack.networking.domain.ext;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import org.openstack4j.model.ModelEntity;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author bboyHan
+ */
+public class NeutronNetQosPolicyRuleTag implements ModelEntity {
+
+    private static final long serialVersionUID = 1L;
+
+    @JsonProperty
+    private List<String> tags = new ArrayList<>();
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public void addTag(String... tags) {
+        this.tags.addAll(Arrays.asList(tags));
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).omitNullValues().add("tags", tags).toString();
+    }
+
+}

--- a/core/src/main/java/org/openstack4j/openstack/networking/internal/NetworkingServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/internal/NetworkingServiceImpl.java
@@ -151,7 +151,7 @@ public class NetworkingServiceImpl implements NetworkingService {
      * {@inheritDoc}
      */
     @Override
-    public NetQosPolicyBLRuleService netQosPolicyBandWidthLimitRule() {
+    public NetQosPolicyBLRuleService netQosPolicyBandwidthLimitRule() {
         return Apis.get(NetQosPolicyBLRuleService.class);
     }
 

--- a/core/src/main/java/org/openstack4j/openstack/networking/internal/NetworkingServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/internal/NetworkingServiceImpl.java
@@ -147,4 +147,12 @@ public class NetworkingServiceImpl implements NetworkingService {
         return Apis.get(NetQosPolicyService.class);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public NetQosPolicyBLRuleService netQosPolicyBandWidthLimitRule() {
+        return Apis.get(NetQosPolicyBLRuleService.class);
+    }
+
 }

--- a/core/src/main/java/org/openstack4j/openstack/networking/internal/ext/NetQosPolicyBLRuleServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/internal/ext/NetQosPolicyBLRuleServiceImpl.java
@@ -1,0 +1,66 @@
+package org.openstack4j.openstack.networking.internal.ext;
+
+import org.openstack4j.api.networking.ext.NetQosPolicyBLRuleService;
+import org.openstack4j.model.common.ActionResponse;
+import org.openstack4j.model.network.ext.NetQosPolicyBandwidthLimitRule;
+import org.openstack4j.openstack.networking.domain.ext.NeutronNetQosPolicyBandwidthLimitRule;
+import org.openstack4j.openstack.networking.domain.ext.NeutronNetQosPolicyBandwidthLimitRule.NeutronNetQosPolicyBLRules;
+import org.openstack4j.openstack.networking.internal.BaseNetworkingServices;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Networking (Neutron) Qos Policy Bandwidth Limit Rule Extension API
+ *
+ * @author bboyHan
+ */
+public class NetQosPolicyBLRuleServiceImpl extends BaseNetworkingServices implements NetQosPolicyBLRuleService {
+
+    @Override
+    public List<? extends NetQosPolicyBandwidthLimitRule> list(String policyId) {
+        checkNotNull(policyId, "qos policyId must not be null");
+        return get(NeutronNetQosPolicyBLRules.class, uri("/qos/policies/%s/bandwidth_limit_rules", policyId)).execute().getList();
+    }
+
+    @Override
+    public NetQosPolicyBandwidthLimitRule get(String policyId, String ruleId) {
+        checkNotNull(policyId, "qos policyId must not be null");
+        checkNotNull(ruleId, "qos ruleId must not be null");
+        return get(NeutronNetQosPolicyBandwidthLimitRule.class, uri("/qos/policies/%s/bandwidth_limit_rules/%s", policyId, ruleId)).execute();
+    }
+
+    @Override
+    public NetQosPolicyBandwidthLimitRule update(String policyId, NetQosPolicyBandwidthLimitRule bandwidthLimitRule) {
+        checkNotNull(policyId, "qos policyId must not be null");
+        checkNotNull(bandwidthLimitRule);
+        checkNotNull(bandwidthLimitRule.getId(), "netQosPolicy rule id must not be null");
+        return put(NeutronNetQosPolicyBandwidthLimitRule.class, uri("/qos/policies/%s/bandwidth_limit_rules/%s",
+                policyId, getAndClearIdentifier(bandwidthLimitRule)))
+                .entity(bandwidthLimitRule).execute();
+    }
+
+    @Override
+    public NetQosPolicyBandwidthLimitRule create(String policyId, NetQosPolicyBandwidthLimitRule bandwidthLimitRule) {
+        checkNotNull(policyId, "qos policyId must not be null");
+        checkNotNull(bandwidthLimitRule, "netQosPolicy ruleId must not be null");
+        return post(NeutronNetQosPolicyBandwidthLimitRule.class, uri("/qos/policies/%s/bandwidth_limit_rules", policyId)).entity(bandwidthLimitRule).execute();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ActionResponse delete(String policyId, String ruleId) {
+        checkNotNull(policyId, "qos policyId must not be null");
+        checkNotNull(ruleId, "netQosPolicy ruleId must not be null");
+        return deleteWithResponse(uri("/qos/policies/%s/bandwidth_limit_rules/%s", policyId, ruleId)).execute();
+    }
+
+    private String getAndClearIdentifier(NetQosPolicyBandwidthLimitRule update) {
+        String id = update.getId();
+        update.setId(null);
+        return id;
+    }
+}

--- a/core/src/main/java/org/openstack4j/openstack/provider/DefaultAPIProvider.java
+++ b/core/src/main/java/org/openstack4j/openstack/provider/DefaultAPIProvider.java
@@ -295,6 +295,7 @@ public class DefaultAPIProvider implements APIProvider {
         bind(NeutronResourceTagService.class, NeutronResourceTagServiceImpl.class);
         bind(PortForwardingService.class, PortForwardingServiceImpl.class);
         bind(NetQosPolicyService.class, NetQosPolicyServiceImpl.class);
+        bind(NetQosPolicyBLRuleService.class, NetQosPolicyBLRuleServiceImpl.class);
     }
 
     /**


### PR DESCRIPTION
# PR description

This PR fix #111 : add bandwidth limit rule API

Based on https://github.com/openstack4j/openstack4j/pull/112 @bboyHan 

Changes:
* 'direction' defined by enum type 'Direction' with a safe jsoncreator
* correct spelling, no 'bandWidth' any more.