### PR TITLE
fix(storage): percent-encode container and object names in request paths

### DIFF
--- a/core/src/main/java/org/openstack4j/model/storage/object/options/ObjectLocation.java
+++ b/core/src/main/java/org/openstack4j/model/storage/object/options/ObjectLocation.java
@@ -1,5 +1,6 @@
 package org.openstack4j.model.storage.object.options;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 /**
@@ -8,6 +9,8 @@ import java.util.Objects;
  * @author Jeremy Unruh
  */
 public final class ObjectLocation {
+
+    private static final char[] HEX = "0123456789ABCDEF".toCharArray();
 
     private String containerName;
     private String objectName;
@@ -35,6 +38,32 @@ public final class ObjectLocation {
     }
 
     public String getURI() {
-        return String.format("/%s/%s", containerName, objectName);
+        return String.format("/%s/%s", encodePath(containerName), encodePath(objectName));
+    }
+
+    /**
+     * Percent-encodes a container or object name for safe inclusion in a request
+     * URL path.  Swift names may contain arbitrary characters (e.g. {@code %},
+     * {@code #}, {@code ?}, spaces, non-ASCII), all of which must be escaped so
+     * the HTTP client does not misinterpret them.  RFC 3986 unreserved characters
+     * are left intact, and {@code /} is preserved so pseudo-directory object names
+     * keep their path structure.
+     *
+     * @param name the raw (unencoded) name
+     * @return the percent-encoded path segment(s)
+     */
+    public static String encodePath(String name) {
+        StringBuilder sb = new StringBuilder(name.length() + 16);
+        for (byte b : name.getBytes(StandardCharsets.UTF_8)) {
+            int c = b & 0xFF;
+            if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+                    || (c >= '0' && c <= '9')
+                    || c == '-' || c == '.' || c == '_' || c == '~' || c == '/') {
+                sb.append((char) c);
+            } else {
+                sb.append('%').append(HEX[(c >> 4) & 0xF]).append(HEX[c & 0xF]);
+            }
+        }
+        return sb.toString();
     }
 }

--- a/core/src/main/java/org/openstack4j/openstack/storage/object/internal/ObjectStorageContainerServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/object/internal/ObjectStorageContainerServiceImpl.java
@@ -12,6 +12,7 @@ import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.storage.object.SwiftContainer;
 import org.openstack4j.model.storage.object.options.ContainerListOptions;
 import org.openstack4j.model.storage.object.options.CreateUpdateContainerOptions;
+import org.openstack4j.model.storage.object.options.ObjectLocation;
 import org.openstack4j.model.storage.object.options.ObjectPutOptions;
 import org.openstack4j.openstack.compute.functions.ToActionResponseFunction;
 import org.openstack4j.openstack.storage.object.domain.SwiftContainerImpl;
@@ -64,7 +65,7 @@ public class ObjectStorageContainerServiceImpl extends BaseObjectStorageService 
     @Override
     public ActionResponse create(String name, CreateUpdateContainerOptions options) {
         Objects.requireNonNull(name);
-        return put(ActionResponse.class, URI_SEP, name).headers(options != null ? options.getOptions(): null).execute();
+        return put(ActionResponse.class, URI_SEP, ObjectLocation.encodePath(name)).headers(options != null ? options.getOptions(): null).execute();
     }
 
     /**
@@ -85,7 +86,7 @@ public class ObjectStorageContainerServiceImpl extends BaseObjectStorageService 
     public ActionResponse update(String name, CreateUpdateContainerOptions options) {
         Objects.requireNonNull(name);
 
-        return post(ActionResponse.class, URI_SEP, name)
+        return post(ActionResponse.class, URI_SEP, ObjectLocation.encodePath(name))
                 .headers(options != null ? options.getOptions(): null)
                 .execute();
     }
@@ -96,7 +97,7 @@ public class ObjectStorageContainerServiceImpl extends BaseObjectStorageService 
     @Override
     public ActionResponse delete(String name) {
         Objects.requireNonNull(name);
-        HttpResponse resp = delete(Void.class, URI_SEP, name).executeWithResponse();
+        HttpResponse resp = delete(Void.class, URI_SEP, ObjectLocation.encodePath(name)).executeWithResponse();
 
         try {
             if (resp.getStatus() == 409)
@@ -114,7 +115,7 @@ public class ObjectStorageContainerServiceImpl extends BaseObjectStorageService 
     @Override
     public Map<String, String> getMetadata(String name) {
         Objects.requireNonNull(name);
-        HttpResponse resp = head(Void.class, URI_SEP, name).executeWithResponse();
+        HttpResponse resp = head(Void.class, URI_SEP, ObjectLocation.encodePath(name)).executeWithResponse();
         try {
             return MapWithoutMetaPrefixFunction.INSTANCE.apply(resp.headers());
         } finally {
@@ -142,7 +143,7 @@ public class ObjectStorageContainerServiceImpl extends BaseObjectStorageService 
         Objects.requireNonNull(name);
         Objects.requireNonNull(metadata);
 
-        return isResponseSuccess(post(Void.class, URI_SEP, name)
+        return isResponseSuccess(post(Void.class, URI_SEP, ObjectLocation.encodePath(name))
                 .headers(MetadataToHeadersFunction.create(prefix).apply(metadata))
                 .executeWithResponse(), 204);
     }

--- a/core/src/main/java/org/openstack4j/openstack/storage/object/internal/ObjectStorageObjectServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/object/internal/ObjectStorageObjectServiceImpl.java
@@ -44,7 +44,7 @@ public class ObjectStorageObjectServiceImpl extends BaseObjectStorageService imp
     @Override
     public List<? extends SwiftObject> list(String containerName) {
         Objects.requireNonNull(containerName);
-        List<SwiftObjectImpl> objs = get(SwiftObjects.class, uri("/%s", containerName)).param("format", "json").execute();
+        List<SwiftObjectImpl> objs = get(SwiftObjects.class, uri("/%s", ObjectLocation.encodePath(containerName))).param("format", "json").execute();
 
         if (objs == null) {
             return Collections.emptyList();
@@ -60,7 +60,7 @@ public class ObjectStorageObjectServiceImpl extends BaseObjectStorageService imp
 
         Objects.requireNonNull(containerName);
 
-        List<SwiftObjectImpl> objs = get(SwiftObjects.class, uri("/%s", containerName)).param("format", "json").params(options.getOptions()).execute();
+        List<SwiftObjectImpl> objs = get(SwiftObjects.class, uri("/%s", ObjectLocation.encodePath(containerName))).param("format", "json").params(options.getOptions()).execute();
         if (objs == null) {
             return Collections.emptyList();
         }
@@ -119,7 +119,7 @@ public class ObjectStorageObjectServiceImpl extends BaseObjectStorageService imp
         if (options.getPath() != null && name.indexOf('/') == -1)
             name = options.getPath() + "/" + name;
 
-        HttpResponse resp = put(Void.class, uri("/%s/%s", containerName, name))
+        HttpResponse resp = put(Void.class, uri("/%s/%s", ObjectLocation.encodePath(containerName), ObjectLocation.encodePath(name)))
                 .entity(payload)
                 .headers(options.getOptions())
                 .contentType(options.getContentType())

--- a/core/src/test/java/org/openstack4j/test/storage/ObjectLocationTest.java
+++ b/core/src/test/java/org/openstack4j/test/storage/ObjectLocationTest.java
@@ -1,0 +1,50 @@
+package org.openstack4j.test.storage;
+
+import org.openstack4j.model.storage.object.options.ObjectLocation;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Tests percent-encoding of container and object names for request paths.
+ */
+public class ObjectLocationTest {
+
+    @Test
+    public void unreservedCharactersArePreserved() {
+        assertEquals(ObjectLocation.encodePath("aZ0-._~"), "aZ0-._~");
+    }
+
+    @Test
+    public void slashIsPreservedForPseudoDirectories() {
+        assertEquals(ObjectLocation.encodePath("dir/sub/file.txt"), "dir/sub/file.txt");
+    }
+
+    @Test
+    public void reservedCharactersAreEscaped() {
+        assertEquals(ObjectLocation.encodePath("a%b"), "a%25b");
+        assertEquals(ObjectLocation.encodePath("a#b"), "a%23b");
+        assertEquals(ObjectLocation.encodePath("a?b"), "a%3Fb");
+        assertEquals(ObjectLocation.encodePath("a b"), "a%20b");
+        assertEquals(ObjectLocation.encodePath("a+b"), "a%2Bb");
+    }
+
+    @Test
+    public void nonAsciiIsUtf8PercentEncoded() {
+        // U+00E9 (é) encodes to 0xC3 0xA9 in UTF-8
+        assertEquals(ObjectLocation.encodePath("café"), "caf%C3%A9");
+        // U+1F600 (emoji) encodes to 0xF0 0x9F 0x98 0x80 in UTF-8
+        assertEquals(ObjectLocation.encodePath("😀"), "%F0%9F%98%80");
+    }
+
+    @Test
+    public void emptyStringEncodesToEmpty() {
+        assertEquals(ObjectLocation.encodePath(""), "");
+    }
+
+    @Test
+    public void getURIEncodesBothNames() {
+        ObjectLocation location = ObjectLocation.create("my container", "weird#name?x");
+        assertEquals(location.getURI(), "/my%20container/weird%23name%3Fx");
+    }
+}


### PR DESCRIPTION
Container and object names were concatenated raw into the request path, and EndpointURIFromRequestFunction only escapes spaces, so names containing reserved characters produced malformed URLs: a bare '%' is an invalid percent-escape that servers reject, while '#' and '?' are parsed as fragment/query delimiters and truncate the name.

Percent-encode each name as an RFC 3986 path segment -- unreserved characters and '/' are preserved so pseudo-directory object names keep their structure -- in ObjectLocation.getURI(), ObjectStorageObjectServiceImpl (put/list) and ObjectStorageContainerServiceImpl. This also encodes the X-Copy-From header, which Swift requires URL-encoded.

Scoped to object storage rather than the shared URL builder because several services (QuotaSet, Magnum, workflow) bake query strings directly into their paths.

# PR description

...

## Submitter checklist

Make sure that following is addressed to make the PR easier to process:

- [x] If applicable, changes are covered by either a unit or a functional test.
- [x] If applicable, changes ware verified manually against an OpenStack instance.
- [ ] If the change is API related, the PR description links to OpenStack API documentation of that particular endpoint/request (https://docs.openstack.org/api-quick-start/#current-api-versions).
- [x] If the change concerns particular OpenStack service, its name is used as a PR name prefix (ex.: "Neutron: Add floatingIp port forwardings service").
- [ ] If the PR closes existing GitHub issue, PR name have prefix: `Fix #NNN: `.
