### PR TITLE
Parse the object Last-Modified header as GMT, not JVM-local time

### DIFF
--- a/core/src/main/java/org/openstack4j/openstack/internal/Parser.java
+++ b/core/src/main/java/org/openstack4j/openstack/internal/Parser.java
@@ -33,6 +33,10 @@ public final class Parser {
 
     static {
         ISO8601_FORMAT.setTimeZone(new SimpleTimeZone(0, "GMT"));
+        // The "GMT" in the RFC822 pattern is a quoted literal, so without an
+        // explicit time zone the time would be parsed in the JVM's default zone
+        // instead of GMT, shifting the result by the local offset.
+        RFC822_FORMAT.setTimeZone(new SimpleTimeZone(0, "GMT"));
     }
 
     /**

--- a/core/src/test/java/org/openstack4j/test/storage/SwiftTimestampParseTest.java
+++ b/core/src/test/java/org/openstack4j/test/storage/SwiftTimestampParseTest.java
@@ -1,0 +1,49 @@
+package org.openstack4j.test.storage;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.TimeZone;
+
+import org.openstack4j.openstack.internal.Parser;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * The object "Last-Modified" header is in GMT, but RFC822_FORMAT uses "'GMT'" as
+ * a quoted literal, so without an explicit zone the time would be parsed in the
+ * JVM's default time zone.
+ *
+ * The test runs under a deliberately non-UTC default zone so that a regression
+ * (parsing in local time) is observable -- under UTC the buggy and fixed code
+ * would agree.  RFC822_FORMAT captures the default zone when Parser is first
+ * loaded, so the zone is set here before any Parser method is called.
+ */
+public class SwiftTimestampParseTest {
+
+    // 2026-06-29T06:37:59Z, computed in UTC so the expectation is independent
+    // of the JVM's default time zone.
+    private static final long EXPECTED_MILLIS =
+            Instant.parse("2026-06-29T06:37:59Z").toEpochMilli();
+
+    private TimeZone savedDefault;
+
+    @BeforeClass
+    public void useNonUtcTimeZone() {
+        savedDefault = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void restoreTimeZone() {
+        TimeZone.setDefault(savedDefault);
+    }
+
+    @Test
+    public void rfc822HeaderIsParsedAsGmt() {
+        Date parsed = Parser.toRFC822DateParse("Mon, 29 Jun 2026 06:37:59 GMT");
+        assertEquals(parsed.getTime(), EXPECTED_MILLIS);
+    }
+}


### PR DESCRIPTION
# PR description

Parser.RFC822_FORMAT uses "'GMT'" as a quoted literal in its pattern but, unlike the adjacent ISO8601_FORMAT, never calls setTimeZone -- so an object's "Last-Modified" header (parsed by ObjectStorageObjectService.get via toRFC822DateParse) was interpreted in the JVM's default time zone, shifting the result by the local offset on non-UTC hosts.

Pin RFC822_FORMAT to GMT and add a regression test that runs under a non-UTC default zone, where the bug is observable.

## Submitter checklist

Make sure that following is addressed to make the PR easier to process:

- [x] If applicable, changes are covered by either a unit or a functional test.
- [x] If applicable, changes ware verified manually against an OpenStack instance.
- [ ] If the change is API related, the PR description links to OpenStack API documentation of that particular endpoint/request (https://docs.openstack.org/api-quick-start/#current-api-versions).
- [ ] If the change concerns particular OpenStack service, its name is used as a PR name prefix (ex.: "Neutron: Add floatingIp port forwardings service").
- [ ] If the PR closes existing GitHub issue, PR name have prefix: `Fix #NNN: `.