### PR TITLE
Expose Cache-Control and Expires on SwiftObject

### DIFF
--- a/core/src/main/java/org/openstack4j/model/storage/object/SwiftHeaders.java
+++ b/core/src/main/java/org/openstack4j/model/storage/object/SwiftHeaders.java
@@ -38,6 +38,8 @@ public final class SwiftHeaders {
     public static final String X_COPY_FROM = "X-Copy-From";
     public static final String CONTENT_LENGTH = "Content-Length";
     public static final String LAST_MODIFIED = "Last-Modified";
+    public static final String CACHE_CONTROL = "Cache-Control";
+    public static final String EXPIRES = "Expires";
 
     private SwiftHeaders() {
     }

--- a/core/src/main/java/org/openstack4j/model/storage/object/SwiftObject.java
+++ b/core/src/main/java/org/openstack4j/model/storage/object/SwiftObject.java
@@ -57,6 +57,20 @@ public interface SwiftObject extends ModelEntity {
     String getMimeType();
 
     /**
+     * The Cache-Control header stored with the object
+     *
+     * @return the Cache-Control header, or null if unset
+     */
+    String getCacheControl();
+
+    /**
+     * The Expires header stored with the object
+     *
+     * @return the Expires header, or null if unset
+     */
+    String getExpires();
+
+    /**
      * @return the container name this object belongs to
      */
     String getContainerName();

--- a/core/src/main/java/org/openstack4j/openstack/storage/object/domain/SwiftObjectImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/object/domain/SwiftObjectImpl.java
@@ -36,6 +36,10 @@ public class SwiftObjectImpl implements SwiftObject {
     private String directoryName;
     @JsonProperty("content_type")
     private String mimeType;
+    @JsonIgnore
+    private String cacheControl;
+    @JsonIgnore
+    private String expires;
 
     @JsonIgnore
     private Map<String, String> metadata;
@@ -75,6 +79,16 @@ public class SwiftObjectImpl implements SwiftObject {
     @Override
     public String getMimeType() {
         return mimeType;
+    }
+
+    @Override
+    public String getCacheControl() {
+        return cacheControl;
+    }
+
+    @Override
+    public String getExpires() {
+        return expires;
     }
 
     @Override
@@ -155,6 +169,16 @@ public class SwiftObjectImpl implements SwiftObject {
 
         public Builder mimeType(String mimeType) {
             obj.mimeType = mimeType;
+            return this;
+        }
+
+        public Builder cacheControl(String cacheControl) {
+            obj.cacheControl = cacheControl;
+            return this;
+        }
+
+        public Builder expires(String expires) {
+            obj.expires = expires;
             return this;
         }
 

--- a/core/src/main/java/org/openstack4j/openstack/storage/object/functions/ParseObjectFunction.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/object/functions/ParseObjectFunction.java
@@ -7,9 +7,11 @@ import org.openstack4j.model.storage.object.options.ObjectLocation;
 import org.openstack4j.openstack.internal.Parser;
 import org.openstack4j.openstack.storage.object.domain.SwiftObjectImpl;
 
+import static org.openstack4j.model.storage.object.SwiftHeaders.CACHE_CONTROL;
 import static org.openstack4j.model.storage.object.SwiftHeaders.CONTENT_LENGTH;
 import static org.openstack4j.model.storage.object.SwiftHeaders.CONTENT_TYPE;
 import static org.openstack4j.model.storage.object.SwiftHeaders.ETAG;
+import static org.openstack4j.model.storage.object.SwiftHeaders.EXPIRES;
 import static org.openstack4j.model.storage.object.SwiftHeaders.LAST_MODIFIED;
 import static org.openstack4j.openstack.internal.Parser.asLong;
 
@@ -37,6 +39,8 @@ public class ParseObjectFunction implements Function<HttpResponse, SwiftObject> 
                 .name(location.getObjectName())
                 .containerName(location.getContainerName())
                 .mimeType(resp.header(CONTENT_TYPE))
+                .cacheControl(resp.header(CACHE_CONTROL))
+                .expires(resp.header(EXPIRES))
                 .sizeBytes(asLong(resp.header(CONTENT_LENGTH)))
                 .eTag(resp.header(ETAG))
                 .metadata(MapWithoutMetaPrefixFunction.INSTANCE.apply(resp.headers()))


### PR DESCRIPTION
# PR description

A plain object GET/HEAD returns the Cache-Control and Expires response headers, but ParseObjectFunction discarded them and SwiftObject had no way to surface them: getMetadata() keeps only X-*-Meta-* and x- headers via MapWithoutMetaPrefixFunction, so neither get() nor getMetadata() exposed them to callers.

Capture both headers in ParseObjectFunction and add getCacheControl() and getExpires() accessors to SwiftObject, mirroring the existing content-type handling.  Add the supporting SwiftHeaders constants.
## Submitter checklist

Make sure that following is addressed to make the PR easier to process:

- [ ] If applicable, changes are covered by either a unit or a functional test.
- [x] If applicable, changes ware verified manually against an OpenStack instance.
- [ ] If the change is API related, the PR description links to OpenStack API documentation of that particular endpoint/request (https://docs.openstack.org/api-quick-start/#current-api-versions).
- [ ] If the change concerns particular OpenStack service, its name is used as a PR name prefix (ex.: "Neutron: Add floatingIp port forwardings service").
- [ ] If the PR closes existing GitHub issue, PR name have prefix: `Fix #NNN: `.
