### PR TITLE
Surface non-2xx statuses from object put() and copy()

### DIFF
--- a/core/src/main/java/org/openstack4j/openstack/storage/object/internal/ObjectStorageObjectServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/object/internal/ObjectStorageObjectServiceImpl.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import org.openstack4j.api.exceptions.ResponseException;
 import org.openstack4j.api.storage.ObjectStorageObjectService;
 import org.openstack4j.core.transport.HttpResponse;
 import org.openstack4j.model.common.ActionResponse;
@@ -126,6 +127,11 @@ public class ObjectStorageObjectServiceImpl extends BaseObjectStorageService imp
                 .paramLists(options.getQueryParams())
                 .executeWithResponse();
         try {
+            // A non-2xx response otherwise slipped through as a null ETag,
+            // hiding errors such as a missing container or an ETag mismatch.
+            if (resp.getStatus() >= 400) {
+                throw ResponseException.mapException(resp);
+            }
             return resp.header(ETAG);
         } finally {
             closeQuietly(resp);
@@ -167,6 +173,11 @@ public class ObjectStorageObjectServiceImpl extends BaseObjectStorageService imp
                 .header(CONTENT_LENGTH, 0)
                 .executeWithResponse();
         try {
+            // A non-2xx response otherwise slipped through as a null ETag,
+            // hiding errors such as a missing container or an ETag mismatch.
+            if (resp.getStatus() >= 400) {
+                throw ResponseException.mapException(resp);
+            }
             return resp.header(ETAG);
         } finally {
             closeQuietly(resp);


### PR DESCRIPTION
# PR description

ObjectStorageObjectServiceImpl.put() and copy() read the ETag off the response but never checked its status, so an error -- a missing container (404), an ETag mismatch (422) and so on -- was silently returned as a null ETag instead of raising.  Throw a ResponseException on a 4xx/5xx status so callers can detect and translate the failure.

## Submitter checklist

Make sure that following is addressed to make the PR easier to process:

- [ ] If applicable, changes are covered by either a unit or a functional test.
- [x] If applicable, changes ware verified manually against an OpenStack instance.
- [ ] If the change is API related, the PR description links to OpenStack API documentation of that particular endpoint/request (https://docs.openstack.org/api-quick-start/#current-api-versions).
- [ ] If the change concerns particular OpenStack service, its name is used as a PR name prefix (ex.: "Neutron: Add floatingIp port forwardings service").
- [ ] If the PR closes existing GitHub issue, PR name have prefix: `Fix #NNN: `.
